### PR TITLE
Adding a more friendly error message for failing to send an email.

### DIFF
--- a/api/services/dispatch/sendSimpleEmail.js
+++ b/api/services/dispatch/sendSimpleEmail.js
@@ -29,8 +29,10 @@ function send (locals, html, text, cb) {
     subject: locals.subject,
     html: html,
     text: text
-  },
-  cb);
+  }, function(err, info) {
+       if (err) sails.log.debug('Failed to send mail. If this is unexpected, please check your settings.');
+       cb(err, info);
+     });
 };
 
 module.exports = {

--- a/api/services/dispatch/sendSimpleEmail.js
+++ b/api/services/dispatch/sendSimpleEmail.js
@@ -30,7 +30,7 @@ function send (locals, html, text, cb) {
     html: html,
     text: text
   }, function(err, info) {
-       if (err) sails.log.debug('Failed to send mail. If this is unexpected, please check your settings.');
+       if (err) sails.log.debug('Failed to send mail. If this is unexpected, please check your email configuration in config/local.js.');
        cb(err, info);
      });
 };


### PR DESCRIPTION
The error message that is raised when email is not configured
to send isn't very informative. This adds a brief message to
provide context for the ECONNREFUSED error message as a 'hint'
for developers.

Fixes #420