### PR TITLE
Adding a Berksfile entry for chef-user.

### DIFF
--- a/chef/Berksfile
+++ b/chef/Berksfile
@@ -1,5 +1,6 @@
 source 'https://api.berkshelf.com'
 
+cookbook 'user', git: 'https://github.com/fnichol/chef-user'
 cookbook 'midas', git: 'https://github.com/18F/midas-cookbook.git'
 cookbook 'postgresql', git: 'https://github.com/phlipper/chef-postgresql.git'
 cookbook 'nginx'


### PR DESCRIPTION
Chef 12 introduced a breaking change by requiring metadata.rb
to contain a name attribute. The released user cookbook, 0.3.0,
does not contain this attribute, and therefore will not work
with the current version of chef. The name attribute is in
Github master, but the maintainers of the repo have not been
responsive about when/if the current version will be released.

This change switches the cookbook to use the Github master
version of the cookbook.