### PR TITLE
Specifying a waterline version to work around file upload bug.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "description": "Innovation platform providing collaboration and crowdsourcing tools",
     "dependencies": {
         "sails": "0.10.5",
+        "waterline": "0.10.13",
         "async": "0.2.9",
         "grunt": "0.4.5",
         "ejs": "0.8.5",


### PR DESCRIPTION
Waterline version 0.10.15 broke the ability to save files specified
as a node Buffer to the database. Specifying version 0.10.13 will
allow uploads to work until they correct the problem.

Fixes #479 (albeit temporarily)