### PR TITLE
Add wildcards for autocomplete query match pattern

### DIFF
--- a/api/services/sources/model.js
+++ b/api/services/sources/model.js
@@ -28,7 +28,7 @@ module.exports = {
         // Set up the where clause
         var where = { where: { like: { } }, limit: field.limit || 10 };
         // Add the search term to find the field
-        where.where.like[field['name']] = term;
+        where.where.like[field['name']] = '%' + term + '%';
       }
       // Extend with configuration options
       _.extend(where.where, field.where || {});

--- a/test/api/sails/tag.test.js
+++ b/test/api/sails/tag.test.js
@@ -196,6 +196,17 @@ describe('tag:', function() {
       });
     });
 
+    it('autocomplete', function(done) {
+      request.get({ url: conf.url + '/ac/tag?q=T' }, function(err, response, body) {
+        if (err) { return done(err); }
+        assert.equal(response.statusCode, 200);
+        var b = JSON.parse(body);
+        assert.equal(b[0].name, tags[0].name);
+        assert.equal(b[0].type, tags[0].type);
+        done();
+      });
+    });
+
   });
 
 });


### PR DESCRIPTION
With the .10 update for Sails, `LIKE` queries need to include wildcards. This adds them for the autocomplete endpoints.

Fixes 18F/midas-open-opportunities#57

@ultrasaurus ready for review