### PR TITLE
since we run ‘make build’ on production

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,17 +28,17 @@
         "sails-disk": "~0.10.0",
         "sails-postgresql": "~0.10.9",
         "sails-build-dictionary": "0.10.1",
-        "i18next": "~1.7.4"
-    },
+        "i18next": "~1.7.4",
+        "grunt-contrib-requirejs": "~0.4.1",
+        "grunt-contrib-cssmin": "*",
+        "grunt-jsonlint" : "*"
+      },
     "devDependencies": {
         "mocha": "*",
         "chai": "*",
         "mocha-casperjs": "^0.5.3",
         "casper-chai": "^0.2.1",
         "request": "2.x",
-        "grunt-contrib-requirejs": "~0.4.1",
-        "grunt-contrib-cssmin": "*",
-        "grunt-jsonlint" : "*",
         "pg" : "~3.6.0"
     },
     "scripts": {


### PR DESCRIPTION
we need additional packages
I added --production to the midas-cookbook npm install to speed up deploys
then it failed since we run 'make build' on production
this commit moves required libraries out of devDependencies