### PR TITLE
Require user name during registration

### DIFF
--- a/assets/js/backbone/apps/login/templates/login_template.html
+++ b/assets/js/backbone/apps/login/templates/login_template.html
@@ -58,17 +58,27 @@
 <div class="modal-body padding-bottom-none" id="registration-view">
     <h2>Create a New Account</h2>
 
-    <div class="form-group">
-      <label for="rusername" class="control-label" data-i18n="loginModal.emailAddress">Email Address</label>
-      <div class="input-group">
-        <input type="text" class="form-control validate" id="rusername" name="username" placeholder="Email Address" data-validate="button"/>
-        <span class="input-group-btn">
-          <a href="#" class="btn btn-danger" id="rusername-button" tabindex="-1">
-            <i id="rusername-check" class="fa fa-times"></i>
-          </a>
-        </span>
+    <div class="row">
+      <div class="col-sm-12">
+        <div class="form-group">
+          <label for="name" class="control-label" data-i18n="loginModal.name">Name</label>
+          <input type="text" class="form-control" id="name" name="name" placeholder="Full Name">
+        </div>
       </div>
-      <span class="help-block error-button" style="display:none;">The email address is not valid or is already in use.</span>
+      <div class="col-sm-12">
+        <div class="form-group">
+          <label for="rusername" class="control-label" data-i18n="loginModal.emailAddress">Email Address</label>
+          <div class="input-group">
+            <input type="text" class="form-control validate" id="rusername" name="username" placeholder="Email Address" data-validate="button"/>
+            <span class="input-group-btn">
+              <a href="#" class="btn btn-danger" id="rusername-button" tabindex="-1">
+                <i id="rusername-check" class="fa fa-times"></i>
+              </a>
+            </span>
+          </div>
+          <span class="help-block error-button" style="display:none;">The email address is not valid or is already in use.</span>
+        </div>
+      </div>
     </div>
 
     <div class="password-view">

--- a/assets/js/backbone/apps/login/templates/login_template.html
+++ b/assets/js/backbone/apps/login/templates/login_template.html
@@ -61,8 +61,9 @@
     <div class="row">
       <div class="col-sm-12">
         <div class="form-group">
-          <label for="name" class="control-label" data-i18n="loginModal.name">Name</label>
-          <input type="text" class="form-control" id="name" name="name" placeholder="Full Name">
+          <label for="rname" class="control-label" data-i18n="loginModal.name">Name</label>
+          <input type="text" class="form-control validate" id="rname" name="rname" placeholder="Full Name" data-validate="empty">
+          <span class="help-block error-empty" style="display:none;">Please enter your full name.</span>
         </div>
       </div>
       <div class="col-sm-12">

--- a/assets/js/backbone/apps/login/views/login_view.js
+++ b/assets/js/backbone/apps/login/views/login_view.js
@@ -83,7 +83,7 @@ define([
       if (e.preventDefault) e.preventDefault();
 
       // validate input fields
-      var validateIds = ['#rusername', '#rpassword'];
+      var validateIds = ['#rname', '#rusername', '#rpassword'];
       // Only validate terms & conditions if it is enabled
       if (this.options.login.terms.enabled === true) {
         validateIds.push('#rterms');
@@ -107,6 +107,7 @@ define([
 
       // Create a data object with the required fields
       var data = {
+        name: this.$("#rname").val(),
         username: this.$("#rusername").val(),
         password: this.$("#rpassword").val(),
         json: true

--- a/config/auth.js
+++ b/config/auth.js
@@ -36,9 +36,10 @@ passport.use('local', new LocalStrategy(
   }
 ));
 
-passport.use('register', new LocalStrategy(
-  function (username, password, done) {
-    userUtils.createLocalUser(username, password, done);
+passport.use('register', new LocalStrategy({ passReqToCallback: true },
+  function (req, username, password, done) {
+    var userData = { displayName: req.param('name') };
+    userUtils.createLocalUser(username, password, userData, null, done);
   }
 ));
 

--- a/test/api/sails/helpers/config.js
+++ b/test/api/sails/helpers/config.js
@@ -6,6 +6,7 @@ module.exports = {
   },
   // for the user.test.js suite
   'testUser': {
+    'name': 'Midas User',
     'username': 'testuser@midascrowd.com',
     'password': 'MidasTestM4$'
   },

--- a/test/api/sails/user.test.js
+++ b/test/api/sails/user.test.js
@@ -24,11 +24,14 @@ describe('user:', function() {
       if (err) { return done(err); }
       assert.equal(response.statusCode, 403);
       request.post({ url: conf.url + '/auth/register',
-                     form: { username: conf.testUser.username, password: conf.testUser.password, json: true },
+                     form: { name: conf.testUser.name, username: conf.testUser.username, password: conf.testUser.password, json: true },
                    }, function (err, response, body) {
         if (err) { return done(err); }
         // Successful login or creation should be a 200 json object
         assert.equal(response.statusCode, 200);
+        var b = JSON.parse(body);
+        assert.equal(b.username, conf.testUser.username);
+        assert.equal(b.name, conf.testUser.name);
         done();
       });
     });


### PR DESCRIPTION
When a user signs up for a new account, we ask for their full name:

![screen shot 2015-01-16 at 3 19 05 pm](https://cloud.githubusercontent.com/assets/170641/5783664/08dec9ec-9d93-11e4-8d0f-f2bd0ccc91cf.png)

It's validated to not be empty:

![screen shot 2015-01-16 at 2 23 16 pm](https://cloud.githubusercontent.com/assets/170641/5783669/163613d4-9d93-11e4-811a-05c8964a851b.png)

And it's saved to their profile on sign-up:

![screen shot 2015-01-16 at 3 18 35 pm](https://cloud.githubusercontent.com/assets/170641/5783679/2cc14e7a-9d93-11e4-853b-ae5e947eda36.png)

Also includes a test to make sure the name saves during registration.

Good to go.

Refs #472 