### PR TITLE
Set up global notification CC and BCC

### DIFF
--- a/api/services/dispatch/sendSimpleEmail.js
+++ b/api/services/dispatch/sendSimpleEmail.js
@@ -26,6 +26,8 @@ function send (locals, html, text, cb) {
   {
     from: locals.from,
     to: locals.to,
+    cc: sails.config.notificationsCC,
+    bcc: sails.config.notificationsBCC,
     subject: locals.subject,
     html: html,
     text: text


### PR DESCRIPTION
If present, a list of addresses to CC or BCC will be added to all outgoing emails.

Use by setting the following in `config/local.js`:

```js
  // System-wide email notification settings
  // Set as a comma-separated list of email addresses
  notificationsCC  : '',
  notificationsBCC : '',
```

Closes #487 