### PR TITLE
[Not ready] Add persistent session store, increase session age

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -220,6 +220,12 @@ If you'd like to include a sample project, also run:
 
 In ```config/models.js```,  set ```migrate: 'safe'```
 
+#### Set up the session table in the database
+
+From the root of the midas directory:
+
+    psql midas < node_modules/connect-pg-simple/table.sql
+    psql midas -c "GRANT ALL PRIVILEGES ON TABLE session TO midas"
 
 Now you are ready to rock!
 

--- a/config/local.ex.js
+++ b/config/local.ex.js
@@ -21,9 +21,13 @@
  * For more information, check out:
  * http://sailsjs.org/#documentation
  */
-var fs = require('fs');
+var fs = require('fs'),
+    pgSession = require('connect-pg-simple'),
+    express = require('sails/node_modules/express'),
+    pg = require('sails-postgresql/node_modules/pg'),
+    local;
 
-module.exports = {
+local = {
   // The name of the system, as should appear in emails and the <html> <title> tag
   systemName: 'midas',
   // 'http' or 'https'
@@ -154,3 +158,13 @@ module.exports = {
     }
   }
 };
+
+// Use main postgres database for sessions
+local.session = {
+  store: new (pgSession(express.session))({
+    conString: local.connections.postgresql,
+    pg: pg
+  })
+};
+
+module.exports = local;

--- a/config/local.ex.js
+++ b/config/local.ex.js
@@ -120,6 +120,11 @@ local = {
     // maxMessages         :
   },
 
+  // System-wide email notification settings
+  // Set as a comma-separated list of email addresses
+  notificationsCC  : '',
+  notificationsBCC : '',
+
   // SES Mail settings -- uses Nodemailer
   ses: {
     // AWSAccessKeyID: 'AWSACCESSKEY',

--- a/config/session.js
+++ b/config/session.js
@@ -1,7 +1,7 @@
 /**
  * Session
- * 
- * Sails session integration leans heavily on the great work already done by Express, but also unifies 
+ *
+ * Sails session integration leans heavily on the great work already done by Express, but also unifies
  * Socket.io with the Connect session store. It uses Connect's cookie parser to normalize configuration
  * differences between Express and Socket.io and hooks into Sails' middleware interpreter to allow you
  * to access and auto-save to `req.session` with Socket.io the same way you would with Express.
@@ -9,19 +9,18 @@
  * For more information on configuring the session, check out:
  * http://sailsjs.org/#documentation
  */
-
 module.exports.session = {
 
   // Session secret is automatically generated when your new app is created
   // Replace at your own risk in production-- you will invalidate the cookies of your users,
-  // forcing them to log in again. 
-  secret: '0fa32505a53e70cd2b5626d70dd15b6c'
+  // forcing them to log in again.
+  secret: '0fa32505a53e70cd2b5626d70dd15b6c',
 
   // Set the cookie maximum age (timeout).  If this is not set, then cookies
   // will persist forever.
-  // cookie: {
-  //   maxAge: 60 * 60 * 1000  // example: 60 mins in miliseconds
-  // }
+  cookie: {
+    maxAge: 30 * 24 * 60 * 60 * 1000 // 30 days
+  }
 
   // In production, uncomment the following lines to set up a shared redis session store
   // that can be shared across multiple Sails.js servers

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "async": "0.2.9",
     "bcrypt": "0.7.7",
+    "connect-pg-simple": "^2.2.1",
     "ejs": "0.8.5",
     "email-templates": "~0.1.5",
     "git-rev": "0.2.x",

--- a/package.json
+++ b/package.json
@@ -1,58 +1,54 @@
 {
-    "name": "midas",
-    "private": true,
-    "version": "0.0.28",
-    "description": "Innovation platform providing collaboration and crowdsourcing tools",
-    "dependencies": {
-        "sails": "0.10.5",
-        "async": "0.2.9",
-        "grunt": "0.4.5",
-        "ejs": "0.8.5",
-        "underscore": "1.x",
-        "lodash": "~2.4.1",
-        "optimist": "0.4.0",
-        "validator": "3.4.0",
-        "passport": "0.2.x",
-        "passport-local": "1.0.x",
-        "passport-myusa": "1.0.x",
-        "passport-linkedin": "0.1.x",
-        "passport-oauth": "1.0.x",
-        "icalendar": "0.6.5",
-        "node-uuid": "1.4.x",
-        "bcrypt": "0.7.7",
-        "string": "~1.8.1",
-        "gm": "~1.14.2",
-        "nodemailer": "0.6.x",
-        "email-templates": "~0.1.5",
-        "git-rev": "0.2.x",
-        "sails-disk": "~0.10.0",
-        "sails-postgresql": "~0.10.9",
-        "sails-build-dictionary": "0.10.1",
-        "i18next": "~1.7.4",
-        "request": "2.x",
-        "grunt-contrib-requirejs": "~0.4.1",
-        "grunt-contrib-cssmin": "*",
-        "grunt-jsonlint" : "*"
-      },
-    "devDependencies": {
-        "mocha": "*",
-        "chai": "*",
-        "mocha-casperjs": "^0.5.3",
-        "casper-chai": "^0.2.1",
-        "pg" : "~3.6.0"
-    },
-    "scripts": {
-        "start": "node app.js",
-        "debug": "node debug app.js"
-    },
-    "main": "app.js",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/18F/midas.git"
-    },
-    "scripts": {
-        "test": "make test"
-    },
-    "bugs": "https://github.com/18F/midas/issues",
-    "license": "MIT"
+  "name": "midas",
+  "private": true,
+  "version": "0.0.28",
+  "description": "Innovation platform providing collaboration and crowdsourcing tools",
+  "dependencies": {
+    "async": "0.2.9",
+    "bcrypt": "0.7.7",
+    "ejs": "0.8.5",
+    "email-templates": "~0.1.5",
+    "git-rev": "0.2.x",
+    "gm": "~1.14.2",
+    "grunt": "0.4.5",
+    "grunt-contrib-cssmin": "*",
+    "grunt-contrib-requirejs": "~0.4.1",
+    "grunt-jsonlint": "*",
+    "i18next": "~1.7.4",
+    "icalendar": "0.6.5",
+    "lodash": "~2.4.1",
+    "node-uuid": "1.4.x",
+    "nodemailer": "0.6.x",
+    "optimist": "0.4.0",
+    "passport": "0.2.x",
+    "passport-linkedin": "0.1.x",
+    "passport-local": "1.0.x",
+    "passport-myusa": "1.0.x",
+    "passport-oauth": "1.0.x",
+    "request": "2.x",
+    "sails": "0.10.5",
+    "sails-build-dictionary": "0.10.1",
+    "sails-disk": "~0.10.0",
+    "sails-postgresql": "~0.10.9",
+    "string": "~1.8.1",
+    "underscore": "1.x",
+    "validator": "3.4.0"
+  },
+  "devDependencies": {
+    "mocha": "*",
+    "chai": "*",
+    "mocha-casperjs": "^0.5.3",
+    "casper-chai": "^0.2.1",
+    "pg": "~3.6.0"
+  },
+  "scripts": {
+    "test": "make test"
+  },
+  "main": "app.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/18F/midas.git"
+  },
+  "bugs": "https://github.com/18F/midas/issues",
+  "license": "MIT"
 }


### PR DESCRIPTION
Increases the session length to 30 days and uses the main postgres database to store sessions. At some point, we'll want to use a separate database for sessions to increase performance, but this should be fine for now. It allows users to stay logged in across multiple web servers or server updates and reboots. 

It also makes development easier by persisting the developer's session over reboots.

Requires an initial setup task after `npm install`:

```bash
psql midas < node_modules/connect-pg-simple/table.sql
psql midas -c "GRANT ALL PRIVILEGES ON TABLE session TO midas"
```

Refs: https://github.com/18F/midas-cookbook/pull/11
Closes: #496 