### PR TITLE
Make "sign up now" link more prominent

### DIFF
--- a/assets/js/backbone/apps/login/templates/login_template.html
+++ b/assets/js/backbone/apps/login/templates/login_template.html
@@ -35,20 +35,20 @@
       <div class="form-group margin-bottom-none">
         <label for="password" class="control-label">Password</label>
         <input type="password" class="form-control" id="password" name="password" placeholder="Password"/>
-      </div>
-  </div>
-  <div class="modal-footer modal-footer-grey" id="login-footer">
-    <div class="row">
-      <div class="col-md-3 col-md-push-9">
-        <button type="submit" class="btn btn-c2 pull-right">Sign in</button>
-      </div>
-      <div class="col-md-9 col-md-pull-3 modal-footer-text">
-        <a href="#forgot-password" id="forgot-password">Forgot your password?</a>
-        <br/>
-        <a href="#login-register" id="login-register">Sign up now</a>
+        <a href="#forgot-password" class="forgot-password" id="forgot-password">Forgot your password?</a>
       </div>
     </div>
-  </div>
+    <div class="modal-footer modal-footer-grey" id="login-footer">
+      <div class="row">
+        <div class="col-md-12">
+          <button type="submit" class="btn btn-c2 pull-right">Sign in</button>
+          <p class="pull-left login-register-label" id="login-register-label">
+            Need an account? 
+            <a href="#login-register" id="login-register">Sign up now</a>
+          </p>
+        </div>
+      </div>
+    </div>
   <% } else { %>
   </div>
   <% } %>

--- a/assets/js/backbone/apps/login/templates/login_template.html
+++ b/assets/js/backbone/apps/login/templates/login_template.html
@@ -44,7 +44,9 @@
           <button type="submit" class="btn btn-c2 pull-right">Sign in</button>
           <p class="pull-left login-register-label" id="login-register-label">
             Need an account? 
-            <a href="#login-register" id="login-register">Sign up now</a>
+            <a href="#login-register" id="login-register">
+              <strong>Sign up now</strong>
+            </a>
           </p>
         </div>
       </div>

--- a/assets/styles/application.css
+++ b/assets/styles/application.css
@@ -443,6 +443,16 @@ ul.metrics > ul > li {
   text-align: center;
 }
 
+.forgot-password {
+  display: block;
+  margin-top: 5px;
+}
+
+.login-register-label {
+  margin: 0;
+  padding-top: 7px;
+}
+
 .btn-login-responsive {
   height: auto;
   max-width: 100%;


### PR DESCRIPTION
I came across this [issue](https://github.com/18F/midas/issues/308) while browsing some of 18F's projects and thought I could help.

What are your thoughts on moving "forgot password" below the password input. That seems to take away some of the noise around the sign-up link.

![screen shot 2015-01-26 at 8 28 59 pm](https://cloud.githubusercontent.com/assets/1540886/5912688/29b5c0c8-a59d-11e4-9eb8-b449eb73f93a.png)
