### PR TITLE
Add modal static attribute. Add cancel button to new event modal.

### DIFF
--- a/assets/js/backbone/apps/browse/templates/browse_main_view_template.html
+++ b/assets/js/backbone/apps/browse/templates/browse_main_view_template.html
@@ -4,9 +4,9 @@
 <div class="row search-row">
   <div class="col-md-3 col-md-push-9 browse-buttons">
     <% if (ui.project.show) { %>
-    <a href="#addProject" class="btn btn-c2 add-project" data-toggle="modal" style="<% if (!user) { %>display: none;<% } %>"><i class="fa fa-plus"></i> <span data-i18n="Project">Project</span></a>
+    <a href="#addProject" class="btn btn-c2 add-project" data-toggle="modal" data-backdrop="static" style="<% if (!user) { %>display: none;<% } %>"><i class="fa fa-plus"></i> <span data-i18n="Project">Project</span></a>
     <% } %>
-    <a href="#addTask" class="btn btn-c2 add-opportunity" data-toggle="modal" style="<% if (!user) { %>display: none;<% } %>"><i class="fa fa-plus"></i> <span data-i18n="Task">Opportunity</span></a>
+    <a href="#addTask" class="btn btn-c2 add-opportunity" data-toggle="modal" data-backdrop="static" style="<% if (!user) { %>display: none;<% } %>"><i class="fa fa-plus"></i> <span data-i18n="Task">Opportunity</span></a>
   </div>
   <div class="col-md-9 col-md-pull-3">
     <form class="form-horizontal" role="form" id="search-form">

--- a/assets/js/backbone/apps/events/list/templates/event_collection_view_template.html
+++ b/assets/js/backbone/apps/events/list/templates/event_collection_view_template.html
@@ -2,7 +2,7 @@
   <h2>
     Upcoming Events
     <% if (user) { %>
-    <a href="#addEvent" class="btn btn-c0 btn-sm file-add add-event" data-toggle="modal">Add Event</a>
+    <a href="#addEvent" class="btn btn-c0 btn-sm file-add add-event" data-toggle="modal" data-backdrop="static">Add Event</a>
     <% } %>
   </h2>
 </div>

--- a/assets/js/backbone/apps/events/new/templates/event_form_template.html
+++ b/assets/js/backbone/apps/events/new/templates/event_form_template.html
@@ -1,7 +1,7 @@
 <form id="event-form" class="form-horizontal" style="display: block;">
 
   <div class="modal-body">
-    
+
     <fieldset>
 
       <div class="form-group">
@@ -21,7 +21,7 @@
           <span class="help-block error-count100" style="display:none;">The event description must be less than 250 characters.</span>
         </div>
       </div>
-      
+
       <div class="form-group">
         <label for="event-start" class="col-md-2 control-label">Time</label>
         <div class="col-md-2 padding-right-none">
@@ -54,10 +54,11 @@
           <span class="help-block error-empty" style="display:none;">You must enter an event location.</span>
         </div>
       </div>
-    
+
     </fieldset>
   </div>
   <div class="modal-footer">
+    <button type="button" class="btn btn-c0 wizard-cancel" data-dismiss="modal">Cancel</button>
     <button class="btn btn-c2" type="submit">Add Event</button>
   </div>
 

--- a/assets/js/backbone/apps/profiles/show/templates/profile_show_template.html
+++ b/assets/js/backbone/apps/profiles/show/templates/profile_show_template.html
@@ -94,7 +94,7 @@
           <div class="col-md-9">
             <div id="profile-emails">
             </div>
-            <a href="#addEmail" class="btn btn-default btn-xs" id="add-email" data-toggle="modal">Add Email Address</a>
+            <a href="#addEmail" class="btn btn-default btn-xs" id="add-email" data-toggle="modal" data-backdrop="static">Add Email Address</a>
           </div>
         </div>
         <div class="form-group">

--- a/assets/js/backbone/apps/tasks/list/templates/task_collection_view_template.html
+++ b/assets/js/backbone/apps/tasks/list/templates/task_collection_view_template.html
@@ -2,7 +2,7 @@
   <h2>
     Available Opportunities
     <% if (user) { %>
-    <a href="#addTask" class="btn btn-c0 btn-sm file-add add-task" data-toggle="modal">Add Opportunity</a>
+    <a href="#addTask" class="btn btn-c0 btn-sm file-add add-task" data-toggle="modal" data-backdrop="static">Add Opportunity</a>
     <% } %>
   </h2>
 </div>


### PR DESCRIPTION
Adds a `backdrop: 'static'` attribute to modal dialogs to prevent closing them by clicking outside of the modal.

Closes #183 
