### PR TITLE
[Not ready] Draft Tasks Workflow

### DIFF
--- a/api/models/Task.js
+++ b/api/models/Task.js
@@ -8,7 +8,7 @@ module.exports = {
     // Current state of the task
     state: {
         type: 'STRING',
-        defaultsTo: 'open'
+        defaultsTo: sails.config.taskState || 'open'
     },
     // user id of the task owner
     userId: 'INTEGER',

--- a/api/models/Task.js
+++ b/api/models/Task.js
@@ -2,6 +2,8 @@
     :: Task
     -> model
 ---------------------*/
+var noteUtils = require('../services/notifications/manager');
+
 module.exports = {
 
   attributes: {
@@ -34,21 +36,25 @@ module.exports = {
     }
   },
 
-  afterCreate: function(model, done) {
-    Notification.create({
-      callerType: 'Task',
-      callerId: model.id,
-      triggerGuid: require('node-uuid').v4(),
-      action: 'taskCreated',
-      createdDate: model.createdAt
-    }).exec(function (err, newNotification){
-      if (err) {
-        sails.log.debug(err);
-        done(null);
-        return false;
+  afterCreate: function(values, done) {
+    var params = {
+      trigger: {
+        callerType: 'Task',
+        callerId: values.id,
+        action: 'taskCreated'
+      },
+      data: {
+        audience: {
+          'user': {
+            fields: {
+              taskId: values.id,
+              userId: values.userId
+            }
+          }
+        }
       }
-      done(null);
-    });
+    };
+    noteUtils.notifier.notify(params, done);
   }
 
 };

--- a/api/services/utils/user.js
+++ b/api/services/utils/user.js
@@ -4,7 +4,7 @@ var async = require('async');
 var tagUtils = require('./tag');
 var noteUtils = require('../notifications/manager');
 
-var sendWelcomeEmail = function(done, user) { 
+var sendWelcomeEmail = function(done, user) {
   // Generate a notification email to the user
   var params = {
     trigger: {

--- a/assets/email/templates/taskCreated/html.ejs
+++ b/assets/email/templates/taskCreated/html.ejs
@@ -1,0 +1,9 @@
+<p>Dear <%= metadata.recipient.name %>,</p>
+
+<p>Thank you for submitting an Open Opportunity.  Someone from our team will review your description and may post it right away or recommend improvements.</p>
+
+<p>
+  Thanks!
+  <br/>
+  - The <%= globals.systemName %> Team
+</p>

--- a/assets/email/templates/taskCreated/html.ejs
+++ b/assets/email/templates/taskCreated/html.ejs
@@ -1,6 +1,10 @@
 <p>Dear <%= metadata.recipient.name %>,</p>
 
-<p>Thank you for submitting an Open Opportunity.  Someone from our team will review your description and may post it right away or recommend improvements.</p>
+<p>Thank you for submitting an Open Opportunity.</p>
+
+<p>For your reference, here's a link the opportunity: <%= globals.urlPrefix %>/tasks/<%= metadata.modelTrigger.taskId %></p>
+
+<p>You will be notified when someone signs up.</p>
 
 <p>
   Thanks!

--- a/assets/email/templates/taskCreated/text.ejs
+++ b/assets/email/templates/taskCreated/text.ejs
@@ -1,6 +1,10 @@
 Dear <%= metadata.recipient.name %>,
 
-Thank you for submitting an Open Opportunity.  Someone from our team will review your description and may post it right away or recommend improvements.
+Thank you for submitting an Open Opportunity.
+
+For your reference, here's a link the opportunity: <%= globals.urlPrefix %>/tasks/<%= metadata.modelTrigger.taskId %>
+
+You will be notified when someone signs up.
 
 Thanks!
 

--- a/assets/email/templates/taskCreated/text.ejs
+++ b/assets/email/templates/taskCreated/text.ejs
@@ -1,0 +1,7 @@
+Dear <%= metadata.recipient.name %>,
+
+Thank you for submitting an Open Opportunity.  Someone from our team will review your description and may post it right away or recommend improvements.
+
+Thanks!
+
+- The <%= globals.systemName %> Team

--- a/assets/js/backbone/apps/browse/templates/browse_main_view_template.html
+++ b/assets/js/backbone/apps/browse/templates/browse_main_view_template.html
@@ -33,11 +33,13 @@
       <% if ( target == "tasks" ) {%>
       <div class="box-pad-lr" id="stateFilters">
         <% _.each(ui.states, function (t) { %>
-          <input type='checkbox' name='state<%- t.label %>' class='stateFilter' value='<%- t.value %>'
+          <label class="<% if ( t.value == "draft" ) { %>hidden draft-filter<% } %>">
+            <input type='checkbox' name='state<%- t.label %>' class='stateFilter' value='<%- t.value %>'
             <% if ( t.value == "open" ) {%>
               <%- checked="checked" %>
             <% } %>
-            > <%- t.label %> <br/>
+            > <%- t.label %>
+          </label>
         <% }); %>
       </div>
       <% } %>

--- a/assets/js/backbone/apps/browse/views/browse_main_view.js
+++ b/assets/js/backbone/apps/browse/views/browse_main_view.js
@@ -180,6 +180,11 @@ define([
         target: this.options.target,
         collection: filteredCollection,
       });
+      // Show draft filter
+      var draft = _(collection).chain()
+            .pluck('state')
+            .indexOf('draft').value() >= 0;
+      $(".draft-filter").toggleClass('hidden', !draft);
       $("#browse-search-spinner").hide();
       $("#browse-list").show();
       this.browseListView.render();

--- a/assets/js/backbone/config/ui.json
+++ b/assets/js/backbone/config/ui.json
@@ -12,5 +12,5 @@
     "pageSize" : 27,
     "useInfiniteScroll" : false
   },
-  "states" : [{"value": "open","label":"Open"},{"value":"assigned","label":"Assigned"},{"value": "completed","label":"Completed"},{"value":"archived","label":"Archived"}]
+  "states" : [{"value": "draft","label":"Draft"},{"value": "open","label":"Open"},{"value":"assigned","label":"Assigned"},{"value": "completed","label":"Completed"},{"value":"archived","label":"Archived"}]
 }

--- a/assets/styles/application.css
+++ b/assets/styles/application.css
@@ -1376,6 +1376,10 @@ ul.task-tags > li {
 .task-show-creation > time {
   font-weight: bold;
 }
+#stateFilters label {
+  display: block;
+  font-weight: normal;
+}
 
 /**********************************
 =  TASKS INFINITE SCROLL OVERFLOW

--- a/config/settings/emailTemplates.ex.js
+++ b/config/settings/emailTemplates.ex.js
@@ -39,7 +39,7 @@ module.exports = {
     'taskCreated': {
       layout: 'default',
       template: 'taskCreated',
-      subject: 'New Opportunity Confirmation',
+      subject: 'New Opportunity Submission',
       templateLocals: { },
       layoutLocals: { }
     },

--- a/config/settings/emailTemplates.ex.js
+++ b/config/settings/emailTemplates.ex.js
@@ -36,6 +36,13 @@ module.exports = {
       templateLocals: { taskTitle: '', taskLink: '', profileLink: '', profileTitle: '', profileName: '', profileLocation: '', profileAgency: '' },
       layoutLocals: { }
     },
+    'taskCreated': {
+      layout: 'default',
+      template: 'taskCreated',
+      subject: 'New Opportunity Confirmation',
+      templateLocals: { },
+      layoutLocals: { }
+    },
     'userPasswordResetEmail': {
       layout: 'default',
       template: 'userPasswordReset',

--- a/config/settings/notifications.ex.js
+++ b/config/settings/notifications.ex.js
@@ -1,5 +1,5 @@
- // NOTIFICATION SETTINGS
- module.exports = {
+// NOTIFICATION SETTINGS
+module.exports = {
   // service functions called to produce the given audience
   audiences : {
     'everyone' : {
@@ -66,6 +66,12 @@
       method: 'prepareTaskVolunteerOwnerEmail',
       settings: {
         emailName: 'taskVolunteerAddedOwnerReply'
+      }
+    },
+    'preflightTaskCreated': {
+      method: 'prepareWelcomeUserEmail',
+      settings: {
+        emailName: 'taskCreated'
       }
     },
     'preflightUserPasswordReset': {
@@ -193,6 +199,18 @@
           strategy: {
             'contactTaskOwnersOnVolunteerEmail': {
               preflight: ['preflightTaskVolunteerOwner'],
+              delivery: 'sendSimpleEmail'
+            }
+          }
+        }
+      }
+    },
+    'taskCreated': {
+      audience:{
+        'user': {
+          strategy: {
+            'contactTaskOwnersOnVolunteerEmail': {
+              preflight: ['preflightTaskCreated'],
               delivery: 'sendSimpleEmail'
             }
           }


### PR DESCRIPTION
# Draft Tasks

This PR pulls together a bunch of different tickets related to setting up a workflow for draft tasks.

## Workflow

Admins set config options to determine the workflow for publishing new tasks. Tasks may either be created as `open` or `draft`. Once a new task is posted, [an email alert](https://github.com/18F/midas/issues/508) goes out to the task creator (admins CCd). The admin or task creator may then update their task to `open` when it's ready to be published to the site.

## Development tasks

- [x] allow tasks to be posted in draft state. 
- [x] set config option for default task state. 
- [x] show draft tasks in task list view to tasks' creators. Closes https://github.com/18F/midas/issues/467
- [ ] set config option for whether only admins can change task draft state. Closes https://github.com/18F/midas/issues/465
- [x] send notification to task creator. Closes https://github.com/18F/midas/issues/508
- [ ] add settings to midas-cookbook for deployment
- [ ] add email templates to open-opportunities

OO-specific notes are here: https://github.com/18F/midas-open-opportunities/issues/61