### PR TITLE
Fix make init

### DIFF
--- a/api/controllers/TagController.js
+++ b/api/controllers/TagController.js
@@ -47,10 +47,12 @@ module.exports = {
   add: function (req, res) {
     if (req.route.method != 'post') { return res.send(400, { message: 'Unsupported operation.' } ); }
     var tag = _.extend(req.body || {}, req.params);
-    // Trim whitespace
+    // Delete undefined tag id added to request
+    delete tag.id;
     if (_.isUndefined(tag.name) || (_.isUndefined(tag.type))) {
       return res.send(400, { message: 'Must specify tag name and type.' });
     }
+    // Trim whitespace
     tag.name = tag.name.trim();
     TagEntity.find({ where: { type: tag.type, name: tag.name }}, function (err, existingTags) {
       if (err) { return res.send(400, { message: 'Error looking up tag' }); }

--- a/api/controllers/TagController.js
+++ b/api/controllers/TagController.js
@@ -65,13 +65,13 @@ module.exports = {
         if (err) { return res.send(400, { message: 'Error creating tag' }); }
         return res.send(tag);
       });
-    });    
+    });
   },
 
   // Override default create to check parameters and
   // ensure duplicate tags are not created.
   create: function (req, res) {
-    if (req.route.method != 'post') { return res.send(400, { message: 'Unsupported operation.' } ); }    
+    if (req.route.method != 'post') { return res.send(400, { message: 'Unsupported operation.' } ); }
     var tag = _.extend(req.body || {}, req.params);
     if (!tag.projectId) { tag.projectId = null; }
     if (!tag.taskId) { tag.taskId = null; }
@@ -106,7 +106,7 @@ module.exports = {
 
   // Override destroy to ensure owner has access to project
   destroy: function (req, res) {
-    if (req.route.method != 'delete') { return res.send(400, { message: 'Unsupported operation.' } ); }    
+    if (req.route.method != 'delete') { return res.send(400, { message: 'Unsupported operation.' } ); }
     var user = req.user[0];
     Tag.findOneById( req.params.id, function (err, tag) {
       if (err) { return res.send(400, { message: 'Error looking up tag' }); }

--- a/test/demo/data/utils.js
+++ b/test/demo/data/utils.js
@@ -105,7 +105,7 @@ module.exports = {
     request.post({ url: url,
                    body: JSON.stringify(obj)
                  }, function(err, response, body) {
-      if (err) { return cb(err, null); }
+      if (err || response.statusCode >= 400) { return cb(err, null); }
       var b = JSON.parse(body);
       cb(null, b);
     });


### PR DESCRIPTION
Two problems were occurring with `make init`:

1. Tests were passing even if responses from the API return error codes >= 400, which was hiding the second problem
2. At some point while handling the request, `req.body.id` is being added as `undefined`. When a model is created with an `undefined` `id`, it fails, because the `id` needs to be not `null`. If the `id` is not present, the database will automatically create one. I'm guessing this showing up now has something to do with the Sails v.10 upgrade.

This PR fixes both issues.

cc @ultrasaurus 

Refs #532 
