### PR TITLE
Set require for login.json to absolute path

### DIFF
--- a/config/local.ex.js
+++ b/config/local.ex.js
@@ -21,6 +21,10 @@
  * For more information, check out:
  * http://sailsjs.org/#documentation
  */
+
+// Set global entry directory
+global.appPath = require('path').dirname(require.main.filename);
+
 var fs = require('fs');
 
 module.exports = {

--- a/config/settings/auth.ex.js
+++ b/config/settings/auth.ex.js
@@ -1,5 +1,5 @@
 // import login configuration
-var config = require('../../assets/js/backbone/config/login.json');
+var config = require(appPath + '/assets/js/backbone/config/login.json');
 module.exports = {
   // AUTHENTICATION SETTINGS
   // Set your client ids private keys for each of your services


### PR DESCRIPTION
@dlapiduz This replaces the relative path with an absolute path. Do you need this of all relative instances or just this one?

For instance, is [this](https://github.com/18F/midas/blob/devel/config/auth.js#L9) a problem?

```js
var authSettings   = require('./settings/auth.js');
```

How about [this](https://github.com/18F/midas/blob/devel/config/auth.js#L10)?

```js
var userUtils      = require('../api/services/utils/user.js');
```