### PR TITLE
Avoid duplicate users with the same email address

### DIFF
--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -133,6 +133,14 @@ module.exports = {
     module.exports.find(req, res);
   },
 
+  emailCount: function(req, res) {
+    var testEmail = req.param('email');
+    User.count({ username: testEmail }).exec(function(err, count) {
+      if (err) { return res.send(400, err); }
+      res.send('' + count);
+    });
+  },
+
   update: function (req, res) {
     return update(req, res);
   },

--- a/api/policies/test.js
+++ b/api/policies/test.js
@@ -1,0 +1,10 @@
+/**
+* Check that the application is running in test mode
+*/
+
+module.exports = function user (req, res, next) {
+  if (process.env.NODE_ENV === 'test') {
+    return next();
+  }
+  return res.send(403, { message: 'Not Authorized.' });
+};

--- a/assets/js/backbone/apps/login/views/login_view.js
+++ b/assets/js/backbone/apps/login/views/login_view.js
@@ -84,9 +84,11 @@ define([
     },
 
     submitRegister: function (e) {
-      var self = this;
+      var self = this,
+          $submitButton = self.$('#registration-form [type="submit"]');
       if (e.preventDefault) e.preventDefault();
 
+      $submitButton.prop('disabled', true);
       // validate input fields
       var validateIds = ['#rname', '#rusername', '#rpassword'];
       // Only validate terms & conditions if it is enabled
@@ -115,6 +117,7 @@ define([
         $(passwordConfirmParent.find('.error-password')[0]).hide();
       }
       if (abort === true || passwordSuccess !== true || passwordConfirmSuccess !== true) {
+        $submitButton.prop('disabled', false);
         return;
       }
 
@@ -142,6 +145,7 @@ define([
         var d = JSON.parse(error.responseText);
         self.$("#registration-error").html(d.message);
         self.$("#registration-error").show();
+        $submitButton.prop('disabled', false);
       });
     },
 

--- a/config/policies.js
+++ b/config/policies.js
@@ -44,7 +44,8 @@ module.exports.policies = {
     'activities': ['authenticated'],
     'disable': ['authenticated', 'requireId', 'requireUserId'],
     'enable': ['authenticated', 'requireId', 'requireUserId', 'admin'],
-    'resetPassword': ['authenticated', 'requireUserId']
+    'resetPassword': ['authenticated', 'requireUserId'],
+    'emailCount': ['test']
   },
 
   UserEmailController : {

--- a/test/api/sails/user.test.js
+++ b/test/api/sails/user.test.js
@@ -36,6 +36,63 @@ describe('user:', function() {
       });
     });
   });
+  it('create duplicate user logged in', function (done) {
+    request.post({
+      url: conf.url + '/auth/register',
+      form: {
+        name: conf.testUser.name,
+        username: conf.testUser.username,
+        password: conf.testUser.password,
+        json: true
+      }
+    }, function (err, response, body) {
+      if (err) { return done(err); }
+      assert.equal(response.statusCode, 200);
+      var email = conf.testUser.username,
+          url = conf.url + '/user/emailCount?email=' + email;
+      request.get(url, function(err, res, matches) {
+        if (err) { return done(err); }
+        assert.equal(res.statusCode, 200);
+        assert.equal(matches, 1);
+        done();
+      });
+    });
+  });
+  it('create duplicate user logged out', function (done) {
+    request(conf.url + '/auth/logout', function (err, response, body) {
+      if (err) { return done(err); }
+      // it redirects for browser
+      assert(response.statusCode === 302);
+      request(conf.url + '/user', function (err, response, body) {
+        if (err) { return done(err); }
+        // Not logged in users should get a 403
+        assert(response.statusCode === 403);
+        next();
+      });
+    });
+    function next() {
+      request.post({
+        url: conf.url + '/auth/register',
+        form: {
+          name: conf.testUser.name,
+          username: conf.testUser.username,
+          password: conf.testUser.password,
+          json: true
+        }
+      }, function (err, response, body) {
+        if (err) { return done(err); }
+        assert.equal(response.statusCode, 200);
+        var email = conf.testUser.username,
+            url = conf.url + '/user/emailCount?email=' + email;
+        request.get(url, function(err, res, matches) {
+          if (err) { return done(err); }
+          assert.equal(res.statusCode, 200);
+          assert.equal(matches, 1);
+          done();
+        });
+      });
+    }
+  });
   it('logout', function (done) {
     request(conf.url + '/auth/logout', function (err, response, body) {
       if (err) { return done(err); }


### PR DESCRIPTION
We have two reported issues of duplicate users with the same email address: #377 and #548 

I've tested that it is not possible to create duplicate local users (normal email and password registration). This PR adds those tests as well a front-end change to disable the new user submit button on submit (prevents double clicking).

The only thing I can think of that may be an issue is when users sign in with MyUSA. Waiting on upstream work to test that.