### PR TITLE
Use postgres for session store

### DIFF
--- a/config/session.js
+++ b/config/session.js
@@ -1,7 +1,27 @@
+var pgSession = require('connect-pg-simple'),
+    express = require('sails/node_modules/express'),
+    pg = require('sails-postgresql/node_modules/pg');
+
+// Build database config
+var environment = process.env.NODE_ENV || 'development',
+    configs = ['./connections', './env/' + environment, './local'],
+    config = {};
+
+(function() {
+  configs.forEach(function(c) {
+    try { extend(config, require(c).connections.postgresql); } catch(e) {}
+  });
+  function extend(obj, props) {
+    for (prop in props) {
+      if (props.hasOwnProperty(prop)) { obj[prop] = props[prop]; }
+    }
+  }
+})();
+
 /**
  * Session
- * 
- * Sails session integration leans heavily on the great work already done by Express, but also unifies 
+ *
+ * Sails session integration leans heavily on the great work already done by Express, but also unifies
  * Socket.io with the Connect session store. It uses Connect's cookie parser to normalize configuration
  * differences between Express and Socket.io and hooks into Sails' middleware interpreter to allow you
  * to access and auto-save to `req.session` with Socket.io the same way you would with Express.
@@ -14,14 +34,19 @@ module.exports.session = {
 
   // Session secret is automatically generated when your new app is created
   // Replace at your own risk in production-- you will invalidate the cookies of your users,
-  // forcing them to log in again. 
-  secret: '0fa32505a53e70cd2b5626d70dd15b6c'
+  // forcing them to log in again.
+  secret: '0fa32505a53e70cd2b5626d70dd15b6c',
 
   // Set the cookie maximum age (timeout).  If this is not set, then cookies
   // will persist forever.
-  // cookie: {
-  //   maxAge: 60 * 60 * 1000  // example: 60 mins in miliseconds
-  // }
+  cookie: {
+    maxAge: 30 * 24 * 60 * 60 * 1000 // 30 days
+  },
+
+  store: new (pgSession(express.session))({
+    conString: config,
+    pg: pg
+  })
 
   // In production, uncomment the following lines to set up a shared redis session store
   // that can be shared across multiple Sails.js servers

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dependencies": {
         "sails": "0.10.5",
         "async": "0.2.9",
+        "connect-pg-simple": "^2.2.1",
         "grunt": "0.4.5",
         "ejs": "0.8.5",
         "underscore": "1.x",


### PR DESCRIPTION
- Adjusts session cookie to 30 days
- Uses `sessions` table in postgres DB for active sessions
- Adds `connect-pg-simple` module for managing session through connect / express

Closes #496