### PR TITLE
Remove null attributes from user model

### DIFF
--- a/assets/js/backbone/entities/profiles/profile_model.js
+++ b/assets/js/backbone/entities/profiles/profile_model.js
@@ -12,6 +12,12 @@ define([
 			this.initializeProfileGet();
 		},
 
+		parse: function(res, options) {
+			// Remove falsy values (db returns null instead of undefined)
+			_(res).each(function(v, k, o) { if (!v) delete o[k]; });
+			return res;
+		},
+
 		initializeProfileGet: function () {
 			var self = this;
 
@@ -79,7 +85,7 @@ define([
 				},
 				error: function (data) {
 					_this.trigger("profile:removeAuth:fail", data, id);
-				} 
+				}
 				});
 			});
 


### PR DESCRIPTION
The DB returns null values for attributes, which sails then uses to overwrite existing values on update. This removes null values when the user model is loaded.

This should resolve https://github.com/18F/midas-open-opportunities/issues/60