### PR TITLE
Add tag creation UI for admins

### DIFF
--- a/assets/js/backbone/apps/admin/templates/admin_tag_template.html
+++ b/assets/js/backbone/apps/admin/templates/admin_tag_template.html
@@ -3,9 +3,18 @@
 <div class="row">
   <div class="col-md-12 box box-pad-lr">
     <div class="row">
-      <div class="col-md-12" style="height: 200px;">
-        <h2>Not Yet Implemented</h2>
-        Coming soon, stay tuned!
+      <div class="col-md-12 box-pad-b">
+        <h2>Find and add tags</h2>
+        <p>Search in the fields below to see existing tags. Type a new tag value to create it.</p>
+        <% _(types).forEach(function(tag) { %>
+          <div class="row box-pad-b box-pad-t">
+            <label for="<%= tag %>" class="col-md-2 control-label"><%= tag %>:</label>
+            <div class="col-md-10">
+              <input type="hidden" id="<%= tag %>" name="<%= tag %>" style="width: 100%"/>
+              <div class="form-status text-success"></div>
+            </div>
+          </div>
+        <% }); %>
       </div>
     </div>
   </div>

--- a/assets/js/backbone/apps/admin/views/admin_tag_view.js
+++ b/assets/js/backbone/apps/admin/views/admin_tag_view.js
@@ -3,8 +3,9 @@ define([
   'underscore',
   'backbone',
   'utilities',
-  'text!admin_tag_template'
-], function ($, _, Backbone, utils, AdminTagTemplate) {
+  'text!admin_tag_template',
+  'tag_factory'
+], function ($, _, Backbone, utils, AdminTagTemplate, TagFactory) {
 
   var AdminTagView = Backbone.View.extend({
 
@@ -13,17 +14,77 @@ define([
 
     initialize: function (options) {
       this.options = options;
+      this.tagFactory = new TagFactory();
     },
 
     render: function () {
+      var types = [
+        'agency',
+        'location',
+        'skill',
+        'topic'
+      ];
       var data = {
-
+        types: types
       };
       var template = _.template(AdminTagTemplate, data);
+      var self = this;
       this.$el.html(template);
       this.$el.show();
+
+      _(types).forEach(this.tagSelector, this);
+
       Backbone.history.navigate('/admin/tag');
       return this;
+    },
+
+    tagSelector: function(type) {
+      var self = this;
+      $('#' + type).select2({
+        placeholder: 'Search for a tag',
+        minimumInputLength: 2,
+        formatResult: function (obj, container, query) {
+          return obj.name;
+        },
+        formatSelection: function (obj, container, query) {
+          return obj.name;
+        },
+        createSearchChoice: function (term, values) {
+          var vals = values.map(function(value) {
+            return value.value.toLowerCase();
+          });
+          return (vals.indexOf(term.toLowerCase()) >=0) ? false : {
+            unmatched: true,
+            tagType: type,
+            id: term,
+            value: term,
+            name: "<b>"+term+"</b> <i>click to create a new tag with this value</i>"
+          };
+        },
+        ajax: {
+          url: '/api/ac/tag',
+          dataType: 'json',
+          data: function (term) {
+            return {
+              type: type,
+              q: term
+            };
+          },
+          results: function (data) {
+            return { results: data };
+          }
+        }
+      }).on('change', function(e) {
+        var $el = self.$(e.currentTarget);
+        self.tagFactory.addTagEntities(e.added, self, function() {
+          $('#' + type).select2('data', null);
+          if (e.added && e.added.value === e.added.id) {
+            $el.next('.form-status').text('Added tag: ' + e.added.value);
+          } else {
+            $el.next('.form-status').text('');
+          }
+        });
+      });
     },
 
     cleanup: function () {

--- a/assets/js/backbone/components/tag_factory.js
+++ b/assets/js/backbone/components/tag_factory.js
@@ -44,8 +44,10 @@ define([
           name: tag.id
         },
         success: function (data){
-          context.data.newTag     = data;
-          context.data.newItemTags.push(data);
+          if (context.data) {
+            context.data.newTag = data;
+            context.data.newItemTags.push(data);
+          }
           return done();
         }
       });
@@ -176,6 +178,3 @@ define([
 
 return Application.Component.TagFactory;
 });
-
-
-


### PR DESCRIPTION
This adds a simple UI to browse and create tags for admins:

![screen shot 2015-02-19 at 6 35 38 pm](https://cloud.githubusercontent.com/assets/170641/6278738/5be94cb8-b867-11e4-855a-a7b465328dfb.png)

![screen shot 2015-02-19 at 6 36 01 pm](https://cloud.githubusercontent.com/assets/170641/6278741/61efbe08-b867-11e4-8e11-d9f69379fec7.png)

![screen shot 2015-02-19 at 6 36 14 pm](https://cloud.githubusercontent.com/assets/170641/6278745/6408ef66-b867-11e4-9dff-d197f80a315c.png)

![screen shot 2015-02-19 at 6 36 36 pm](https://cloud.githubusercontent.com/assets/170641/6278747/66b212d8-b867-11e4-88da-cf64584f129c.png)

Allows admins to handle requests like https://github.com/18F/midas-open-opportunities/issues/79 without needing to access the DB directly.