### PR TITLE
Add interactions to admin dashboard

### DIFF
--- a/api/controllers/AdminController.js
+++ b/api/controllers/AdminController.js
@@ -189,6 +189,7 @@ module.exports = {
       },
       tasks: {
         count: 0,
+        draft: 0,
         open: 0,
         assigned: 0,
         completed: 0,
@@ -215,6 +216,8 @@ module.exports = {
             metrics.tasks.completed++;
           } else if (tasks[i].state === "archived") {
             metrics.tasks.archived++;
+          } else if (tasks[i].state === "draft") {
+            metrics.tasks.draft++;
           }
         }
         Volunteer.find().sort('taskId').exec(function(err, vols) {

--- a/api/controllers/AdminController.js
+++ b/api/controllers/AdminController.js
@@ -572,22 +572,73 @@ module.exports = {
   interactions: function(req, res) {
     /**
     * The interaction metric is the total of the following actions:
-    * - someone signs up for an opportunity
-    * - task creator assigns the opportunity
-    * - posting to the discussion
-    * - marking a task completed
-    * - someone creates an opportunity in draft
-    * - an opportunity is published
+    * + someone signs up for an opportunity
+    * + task creator assigns the opportunity
+    * + posting to the discussion
+    * + marking a task completed
+    * + someone creates an opportunity in draft
+    * + an opportunity is published
     */
     var interactions = {
-      signups: 0,
-      assignments: 0,
-      posts: 0,
-      completions: 0,
-      drafts: 0,
-      publishes: 0
-    };
-    res.send(interactions);
+          signups: 0,
+          assignments: 0,
+          posts: 0,
+          completions: 0,
+          drafts: 0,
+          publishes: 0
+        },
+        page = parseInt(req.param('page', 1)),
+        limit = req.param('limit', 1000),
+        sort = req.param('sort', 'createdAt desc'),
+        steps = [];
+
+    steps.push(function(done) {
+      Task.find({}).sort(sort).paginate({
+        page: page,
+        limit: limit
+      }).exec(function(err, tasks) {
+        if (err) { return done(err); }
+        interactions.assignments = tasks.reduce(function(count, task) {
+          return (task.assignedAt) ? count + 1 : count;
+        }, 0);
+        interactions.completions = tasks.reduce(function(count, task) {
+          return (task.completedAt) ? count + 1 : count;
+        }, 0);
+        interactions.drafts = tasks.reduce(function(count, task) {
+          return (task.createdAt) ? count + 1 : count;
+        }, 0);
+        interactions.publishes = tasks.reduce(function(count, task) {
+          return (task.publishedAt) ? count + 1 : count;
+        }, 0);
+        done();
+      });
+    });
+
+    steps.push(function(done) {
+      Comment.count({}).exec(function(err, count) {
+        if (err) { return done(err); }
+        interactions.posts = count;
+        done();
+      });
+    });
+
+    steps.push(function(done) {
+      Volunteer.count({}).exec(function(err, count) {
+        if (err) { return done(err); }
+        interactions.signups = count;
+        done();
+      });
+    });
+
+    async.parallel(steps, function(err) {
+      if (err) {
+        return res.send(400, {
+          message: 'Error generating interactions.',
+          err: err
+        });
+      }
+      res.send(interactions);
+    });
   },
 
   /**

--- a/api/controllers/AdminController.js
+++ b/api/controllers/AdminController.js
@@ -566,6 +566,31 @@ module.exports = {
   },
 
   /**
+  * Measure key interactions: http://git.io/AOkF
+  * eg: /api/admin/interactions
+  */
+  interactions: function(req, res) {
+    /**
+    * The interaction metric is the total of the following actions:
+    * - someone signs up for an opportunity
+    * - task creator assigns the opportunity
+    * - posting to the discussion
+    * - marking a task completed
+    * - someone creates an opportunity in draft
+    * - an opportunity is published
+    */
+    var interactions = {
+      signups: 0,
+      assignments: 0,
+      posts: 0,
+      completions: 0,
+      drafts: 0,
+      publishes: 0
+    };
+    res.send(interactions);
+  },
+
+  /**
    * Overrides for the settings in `config/controllers.js`
    * (specific to AdminController)
    */

--- a/assets/js/backbone/apps/admin/templates/admin_dashboard_table.html
+++ b/assets/js/backbone/apps/admin/templates/admin_dashboard_table.html
@@ -11,6 +11,7 @@
     <ul class="metrics">
       <li>Total Created: <%- tasks.count %></li>
       <ul>
+        <li>Draft: <%- tasks.draft %></li>
         <li>Open: <%- tasks.open %></li>
         <li>Assigned: <%- tasks.assigned %></li>
         <li>Completed: <%- tasks.completed %></li>

--- a/assets/js/backbone/apps/admin/templates/admin_dashboard_table.html
+++ b/assets/js/backbone/apps/admin/templates/admin_dashboard_table.html
@@ -1,12 +1,19 @@
 <div class="row">
-  <div class="col-sm-4">
-    <h2><i class="fa fa-user"></i><span class="box-icon-text">Users</span></h2>
+  <div class="col-sm-6 box-pad-t box-pad-b">
+    <h2><i class="fa fa-line-chart"></i><span class="box-icon-text" data-i18n="InteractionPlural">Interactions</span></h2>
     <ul class="metrics">
-      <li>Quantity: <%- users.count %></li>
-      <ul><li>Who have created tasks: <%- users.withTasks %></li></ul>
+      <li>Total Interactions: <%- interactions.count %></li>
+      <ul>
+        <li>Signups: <%- interactions.signups %></li>
+        <li>Assignments: <%- interactions.assignments %></li>
+        <li>Discussion Posts: <%- interactions.posts %></li>
+        <li>Completed Tasks: <%- interactions.completions %></li>
+        <li>Draft Tasks: <%- interactions.drafts %></li>
+        <li>Published Tasks: <%- interactions.publishes %></li>
+      </ul>
     </ul>
   </div>
-  <div class="col-sm-4">
+  <div class="col-sm-6 box-pad-t box-pad-b">
     <h2><i class="fa fa-tags"></i><span class="box-icon-text" data-i18n="TaskPlural">Tasks</span></h2>
     <ul class="metrics">
       <li>Total Created: <%- tasks.count %></li>
@@ -19,7 +26,16 @@
       </ul>
     </ul>
   </div>
-  <div class="col-sm-4">
+</div>
+<div class="row">
+  <div class="col-sm-6 box-pad-t box-pad-b">
+    <h2><i class="fa fa-user"></i><span class="box-icon-text">Users</span></h2>
+    <ul class="metrics">
+      <li>Quantity: <%- users.count %></li>
+      <ul><li>Who have created tasks: <%- users.withTasks %></li></ul>
+    </ul>
+  </div>
+  <div class="col-sm-6 box-pad-t box-pad-b">
     <h2><i class="fa fa-rocket"></i><span class="box-icon-text" data-i18n="ProjectPlural">Projects</span></h2>
     <ul class="metrics">
       <li>Total Created: <%- projects.count %></li>

--- a/assets/js/backbone/apps/admin/views/admin_dashboard_view.js
+++ b/assets/js/backbone/apps/admin/views/admin_dashboard_view.js
@@ -81,7 +81,21 @@ define([
         data: data,
         success: function (data) {
           self.data = data;
-          self.renderMetrics(self, data);
+          $.ajax({
+            url: '/api/admin/interactions',
+            dataType: 'json',
+            data: data,
+            success: function(interactions) {
+              data.interactions = interactions;
+              interactions.count = _(interactions).reduce(function(sum, value, key) {
+                return sum + value;
+              }, 0);
+              self.renderMetrics(self, data);
+            },
+            error: function (xhr, status, error) {
+              self.handleError(self, xhr, status, error);
+            }
+          });
         },
         error: function (xhr, status, error) {
           self.handleError(self, xhr, status, error);


### PR DESCRIPTION
Adds a section to the admin dashboard that counts interactions, as described in https://github.com/18F/midas-open-opportunities/issues/73

![screen shot 2015-02-19 at 7 34 13 pm](https://cloud.githubusercontent.com/assets/170641/6279363/a55a4d28-b86e-11e4-999d-4452e0cf8728.png)

cc @ultrasaurus 

Also adds drafts to the task counts on the dashboard.