### PR TITLE
Add datetime fields on task edit form

### DIFF
--- a/assets/js/backbone/apps/tasks/edit/templates/task_edit_form_template.html
+++ b/assets/js/backbone/apps/tasks/edit/templates/task_edit_form_template.html
@@ -102,6 +102,23 @@
     <small>Leave empty if people can participate from anywhere</small>
 
     <hr/>
+
+    Pubished date:<br>
+    <div class="col-md-12 padding-none" id="div-publishedAt">
+      <input id="publishedAt" name="publishedAt" class="form-control timepicker" type="text">
+    </div>
+    Assigned date:<br>
+    <div class="col-md-12 padding-none" id="div-assignedAt">
+      <input id="assignedAt" name="assignedAt" class="form-control timepicker" type="text">
+    </div>
+    Completed date:<br>
+    <div class="col-md-12 padding-none" id="div-completedAt">
+      <input id="completedAt" name="completedAt" class="form-control timepicker" type="text">
+    </div>
+    <div class="clearfix">
+      <hr>
+    </div>
+
   </div>
   <div class="row">
     <div class="col-lg-12">

--- a/assets/js/backbone/apps/tasks/edit/views/task_edit_form_view.js
+++ b/assets/js/backbone/apps/tasks/edit/views/task_edit_form_view.js
@@ -67,6 +67,18 @@ define([
       // DOM now exists, begin select2 init
       this.initializeSelect2();
       this.initializeTextArea();
+
+      // Set up time pickers
+      $('#publishedAt').datetimepicker({
+        defaultDate: this.data.data.publishedAt
+      });
+      $('#assignedAt').datetimepicker({
+        defaultDate: this.data.data.assignedAt
+      });
+      $('#completedAt').datetimepicker({
+        defaultDate: this.data.data.completedAt
+      });
+
     },
 
     initializeSelect2: function () {
@@ -198,7 +210,10 @@ define([
 
         var modelData = {
           title: this.$("#task-title").val(),
-          description: this.$("#task-description").val()
+          description: this.$("#task-description").val(),
+          publishedAt: this.$("#publishedAt").val(),
+          assignedAt: this.$("#assignedAt").val(),
+          completedAt: this.$("#completedAt").val()
         };
 
         var project = this.$("#projectId").select2('data');
@@ -312,7 +327,7 @@ define([
 
       return oldTags;
     },
-    
+
     cleanup: function () {
       if (this.md) { this.md.cleanup(); }
       removeView(this);


### PR DESCRIPTION
Adds fields to set the published, assigned, and completed time for tasks.

![screen shot 2015-02-20 at 5 45 53 pm](https://cloud.githubusercontent.com/assets/170641/6311161/bec71886-b92c-11e4-986f-b534fd65aec5.png)

Closes #595 