### PR TITLE
[Not ready] Change default task browse state to open from not draft

### DIFF
--- a/api/controllers/TaskController.js
+++ b/api/controllers/TaskController.js
@@ -28,13 +28,13 @@ module.exports = {
     // Only show drafts for current user
     if (user) {
       where = { or: [{
-        state: {'!': 'draft'}
+        state: 'open'
       }, {
         state: 'draft',
         userId: user.id
       }]};
     } else {
-      where.state = {'!': 'draft'};
+      where.state = 'open';
     }
 
     // run the common task find query


### PR DESCRIPTION
The default browse state of not draft returns all task from the server and then is filtered down to only open tasks on the client side.

This change does this filtering on the server, increasing the responsiveness. It does not affect the search / filtering behavior once tasks are rendered.

Addresses #605 