### PR TITLE
Stops app crash when tag data is incomplete

### DIFF
--- a/api/services/utils/user.js
+++ b/api/services/utils/user.js
@@ -759,29 +759,32 @@ module.exports = {
           delete tags[i].updatedAt;
           delete tags[i].deletedAt;
           delete tags[i].userId;
-          delete tags[i].tag.createdAt;
-          delete tags[i].tag.updatedAt;
-          delete tags[i].tag.deletedAt;
-          if (tags[i].tag.type == 'agency') {
-            if (!user.agency) {
-              user.agency = tags[i];
-            } else {
-              // always use the latest tag stored, in case multiple are stored
-              if (user.agency.createdAt < tags[i].createdAt) {
+
+          if ( typeof tags[i].tag != 'undefined' ){
+            delete tags[i].tag.createdAt;
+            delete tags[i].tag.updatedAt;
+            delete tags[i].tag.deletedAt;
+            if (tags[i].tag.type == 'agency') {
+              if (!user.agency) {
                 user.agency = tags[i];
+              } else {
+                // always use the latest tag stored, in case multiple are stored
+                if (user.agency.createdAt < tags[i].createdAt) {
+                  user.agency = tags[i];
+                }
               }
             }
-          }
-          if (tags[i].tag.type == 'location') {
-            if (!user.location) {
-              user.location = tags[i];
-            } else {
-              // always use the latest tag stored, in case multiple are stored
-              if (user.location.createdAt < tags[i].createdAt) {
+            if (tags[i].tag.type == 'location') {
+              if (!user.location) {
                 user.location = tags[i];
+              } else {
+                // always use the latest tag stored, in case multiple are stored
+                if (user.location.createdAt < tags[i].createdAt) {
+                  user.location = tags[i];
+                }
               }
             }
-          }
+         }
          }
         user.tags = tags;
         Like.countByTargetId(userId, function (err, likes) {


### PR DESCRIPTION
When browsing tasks, the application crashes if it attempts to access tags[i].tag when tag is undefined.

This appears to be related to relations defined in the tag table no longer existing or being corrupt. 

If the data is complete, this will have no effect. If the data is incomplete the browse will never complete, even if forever is working and catches the application crash.