### PR TITLE
Add text when no search results

### DIFF
--- a/assets/js/backbone/apps/browse/templates/no_search_results.html
+++ b/assets/js/backbone/apps/browse/templates/no_search_results.html
@@ -1,0 +1,16 @@
+<span data-i18n='[html]noSearchResults.text'>
+<h2>Oops we didn't find any results</h2>
+<p>Maybe your search was too specific. You could try including more filters like <b>Completed</b> or <b>Archived</b>. Maybe there are too many search terms, try removing some or using more general terms.</p>
+<p>Still not finding what you wanted?</p>
+<p>Did you mean to:</p>
+</span>
+	<ul>
+		<% if (ui.project.show) { %>
+		<li>Look for <span data-i18n="ProjectIndefinite">a Project</span>? Try going to Browse <span data-i18n="ProjectPlural">Projects</span> or clicking <a href='/projects'>here</a> .</li>
+		<% } %>
+		<li>Look for <span data-i18n="TaskIndefinite">a Task</span>? Try going to Browse <span data-i18n="TaskPlural">Tasks</span> or clicking <a href='/tasks'>here</a> . </li>
+		<% if (ui.faq.show) { %>
+		<li>Get an answer to a general question? Try reading the FAQ by clicking <a href='<%- ui.faq.url %>'>here</a> .</li>
+		<% } %>
+		<li>Get an answer to a specific question you can't find elsewhere? Trying <a href='mailto:<%- ui.systemEmail %>'>sending an email to the team .</a></li>
+	</ul>

--- a/assets/js/backbone/apps/browse/views/browse_list_view.js
+++ b/assets/js/backbone/apps/browse/views/browse_list_view.js
@@ -2,14 +2,16 @@ define([
   'jquery',
   'underscore',
   'backbone',
+  'i18n',
   'async',
   'utilities',
   'json!ui_config',
   'marked',
   'tag_config',
   'text!project_list_item',
-  'text!task_list_item'
-], function ($, _, Backbone, async, utils, UIConfig, marked, TagConfig, ProjectListItem, TaskListItem) {
+  'text!task_list_item',
+  'text!no_search_results'
+], function ($, _, Backbone, i18n, async, utils, UIConfig, marked, TagConfig, ProjectListItem, TaskListItem, NoListItem) {
 
   var BrowseListView = Backbone.View.extend({
 
@@ -73,32 +75,41 @@ define([
         var start = 0;
       }
 
-      for ( i = start; i < limit; i++ ){
-
-      if ( typeof this.options.collection[i] == 'undefined' ){ break; }
-        var item = {
-          item: this.options.collection[i],
-          user: window.cache.currentUser,
-          tagConfig: TagConfig,
-          tagShow: ['location', 'skill', 'topic', 'task-time-estimate', 'task-time-required']
+      if ( this.options.collection.length == 0 ){
+        var settings = {
+          ui: UIConfig
         }
-        if (this.options.collection[i].tags) {
-          item.tags = this.organizeTags(this.options.collection[i].tags);
-        } else {
-          item.tags =[];
-        }
-        if (this.options.collection[i].description) {
-          item.item.descriptionHtml = marked(this.options.collection[i].description);
-        }
-        var compiledTemplate = '';
-        if (this.options.target == 'projects') {
-          compiledTemplate = _.template(ProjectListItem, item);
-        } else {
-          compiledTemplate = _.template(TaskListItem, item);
-        }
+        compiledTemplate = _.template(NoListItem, settings);
         this.$el.append(compiledTemplate);
-      }
+      } else {
 
+        for ( i = start; i < limit; i++ ){
+
+        if ( typeof this.options.collection[i] == 'undefined' ){ break; }
+          var item = {
+            item: this.options.collection[i],
+            user: window.cache.currentUser,
+            tagConfig: TagConfig,
+            tagShow: ['location', 'skill', 'topic', 'task-time-estimate', 'task-time-required']
+          }
+          if (this.options.collection[i].tags) {
+            item.tags = this.organizeTags(this.options.collection[i].tags);
+          } else {
+            item.tags =[];
+          }
+          if (this.options.collection[i].description) {
+            item.item.descriptionHtml = marked(this.options.collection[i].description);
+          }
+          var compiledTemplate = '';
+          if (this.options.target == 'projects') {
+            compiledTemplate = _.template(ProjectListItem, item);
+          } else {
+            compiledTemplate = _.template(TaskListItem, item);
+          }
+          this.$el.append(compiledTemplate);
+        }
+      }
+      this.$el.i18n();
       return this;
     },
 

--- a/assets/js/backbone/config/require_config.js
+++ b/assets/js/backbone/config/require_config.js
@@ -105,6 +105,7 @@ require.config({
     'browse_search_tag'         : '../apps/browse/templates/browse_search_tag.html',
     'project_list_item'         : '../apps/browse/templates/project_list_item.html',
     'task_list_item'            : '../apps/browse/templates/task_list_item.html',
+    'no_search_results'         : '../apps/browse/templates/no_search_results.html',
 
     // ----------
     //= Projects

--- a/assets/js/backbone/config/ui.json
+++ b/assets/js/backbone/config/ui.json
@@ -1,6 +1,6 @@
 {
   "project": {
-    "show": false
+    "show": true
   },
   "supervisorEmail": {
 	  "useSupervisorEmail": false

--- a/assets/js/backbone/config/ui.json
+++ b/assets/js/backbone/config/ui.json
@@ -1,6 +1,6 @@
 {
   "project": {
-    "show": true
+    "show": false
   },
   "supervisorEmail": {
 	  "useSupervisorEmail": false
@@ -8,6 +8,11 @@
   "home": {
     "logged_in_path": "/projects"
   },
+  "faq" : {
+    "show" : false,
+    "url"  : "/faq"
+  },
+  "systemEmail" : "crowdwork@state.gov",
   "browse": {
     "pageSize" : 27,
     "useInfiniteScroll" : false

--- a/assets/js/backbone/config/ui.json
+++ b/assets/js/backbone/config/ui.json
@@ -12,7 +12,7 @@
     "show" : false,
     "url"  : "/faq"
   },
-  "systemEmail" : "crowdwork@state.gov",
+  "systemEmail" : "test@midas.com",
   "browse": {
     "pageSize" : 27,
     "useInfiniteScroll" : false

--- a/assets/locales/en-US/translation.json
+++ b/assets/locales/en-US/translation.json
@@ -70,5 +70,9 @@
       "likes" : "Error looking up $(task) $(likePlural).",
       "volunteers" : "Error looking up $t(task) $t(volunteerPlural)."
     }
+  },
+
+  "noSearchResults": {
+    "text" : "<h2>Oops we didn't find any results</h2><p>Maybe your search was too specific. You could try including more filters like <b>Completed</b> or <b>Archived</b>. Maybe there are too many search terms, try removing some or using more general terms.</p><p>Still not finding what you wanted?</p><p>Did you mean to:</p>"
   }
 }

--- a/assets/locales/en/translation.json
+++ b/assets/locales/en/translation.json
@@ -69,5 +69,9 @@
       "likes" : "Error looking up $(task) $(likePlural).",
       "volunteers" : "Error looking up $t(task) $t(volunteerPlural)."
     }
+  },
+
+  "noSearchResults": {
+    "text" : "<h2>Oops we didn't find any results</h2><p>Maybe your search was too specific. You could try including more filters like <b>Completed</b> or <b>Archived</b>. Maybe there are too many search terms, try removing some or using more general terms.</p><p>Still not finding what you wanted?</p><p>Did you mean to:</p>"
   }
 }


### PR DESCRIPTION
Text displayed when there are no search or browse results to replace the current behavior of no feedback at all.

Uses uiconfig to decide to show Projects or FAQ lines.
Stores top text in translation file, so it can be customized per installation.
Uses uiconfig for systemEmail mailto for last line.
Is it's own template so a design can be implemented at a later date.

Addresses #101 