### PR TITLE
Add sample data. Add more browser tests for tasks.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,8 @@ test-all: test-all-current-config
 start: server.PID
 
 server.PID:
+	mkdir -p .tmp
+	cp test/data/disk.db .tmp/disk.db
 	@NODE_ENV=test sails lift & echo $$! > $@;
 	sleep 15
 

--- a/test-browser/task.js
+++ b/test-browser/task.js
@@ -28,11 +28,33 @@ describe('Task page', function() {
     })
   })
 
-  it('should have task list', function() {
+  it('should have task listing page', function() {
     casper.then(function() {
       casper.waitForSelector('#browse-list', loaded, failed, 1000 * 15);
       function loaded() {
         assert.ok(true);
+      }
+      function failed() {
+        assert.ok(false);
+      }
+    });
+  });
+
+  it('should have task list with tasks', function() {
+    casper.then(function() {
+      assert.equal(1, casper.getElementsInfo('.task-box').length);
+    });
+  });
+
+  it('should have task page with matching content', function() {
+    var sel = '.task-box .task-list-title a',
+        linkTitle = casper.fetchText(sel).trim();
+    casper.click(sel);
+    casper.then(function() {
+      var sel = '.main-section h1';
+      casper.waitForSelector(sel, loaded, failed, 1000 * 15);
+      function loaded() {
+        assert.equal(linkTitle, casper.fetchText(sel).trim());
       }
       function failed() {
         assert.ok(false);

--- a/test/data/disk.db
+++ b/test/data/disk.db
@@ -1,0 +1,1104 @@
+{
+  "data": {
+    "attachment": [],
+    "comment": [
+      {
+        "topic": true,
+        "projectId": 2,
+        "userId": 3,
+        "value": "Swift as a deer. Quiet as a shadow. Fear cuts deeper than swords. Quick as a snake. Calm as still water.",
+        "id": 1,
+        "createdAt": "2015-02-24T22:52:18.260Z",
+        "updatedAt": "2015-02-24T22:52:18.260Z"
+      },
+      {
+        "topic": false,
+        "projectId": 2,
+        "parentId": 1,
+        "userId": 4,
+        "value": "Winter is coming.",
+        "id": 2,
+        "createdAt": "2015-02-24T22:52:18.512Z",
+        "updatedAt": "2015-02-24T22:52:18.512Z"
+      },
+      {
+        "topic": true,
+        "projectId": 2,
+        "userId": 4,
+        "value": "The man who passes the sentence should swing the sword. ",
+        "id": 3,
+        "createdAt": "2015-02-24T22:52:18.814Z",
+        "updatedAt": "2015-02-24T22:52:18.814Z"
+      }
+    ],
+    "delivery": [],
+    "event": [],
+    "eventrsvp": [],
+    "file": [],
+    "like": [],
+    "notification": [],
+    "project": [
+      {
+        "state": "open",
+        "title": "Health and Safety",
+        "description": "We are interested in projects that improve the health and safety of the American people.",
+        "id": 1,
+        "createdAt": "2015-02-24T22:52:16.497Z",
+        "updatedAt": "2015-02-24T22:52:16.764Z"
+      },
+      {
+        "state": "open",
+        "title": "Education Resources",
+        "description": "We are focused on improving access to education resources for K-12 through use of digital tools, online access and social media.",
+        "id": 2,
+        "createdAt": "2015-02-24T22:52:17.736Z",
+        "updatedAt": "2015-02-24T22:52:17.991Z"
+      }
+    ],
+    "projectowner": [
+      {
+        "projectId": 1,
+        "userId": 3,
+        "id": 1,
+        "createdAt": "2015-02-24T22:52:16.500Z",
+        "updatedAt": "2015-02-24T22:52:16.500Z"
+      },
+      {
+        "projectId": 2,
+        "userId": 1,
+        "id": 2,
+        "createdAt": "2015-02-24T22:52:17.739Z",
+        "updatedAt": "2015-02-24T22:52:17.739Z"
+      }
+    ],
+    "projectparticipant": [],
+    "projecttag": [],
+    "tag": [
+      {
+        "projectId": null,
+        "taskId": null,
+        "tagId": 11,
+        "userId": 1,
+        "id": 1,
+        "createdAt": "2015-02-24T22:52:14.462Z",
+        "updatedAt": "2015-02-24T22:52:14.462Z"
+      },
+      {
+        "projectId": null,
+        "taskId": null,
+        "tagId": 9,
+        "userId": 1,
+        "id": 2,
+        "createdAt": "2015-02-24T22:52:14.738Z",
+        "updatedAt": "2015-02-24T22:52:14.738Z"
+      },
+      {
+        "projectId": null,
+        "taskId": null,
+        "tagId": 11,
+        "userId": 2,
+        "id": 3,
+        "createdAt": "2015-02-24T22:52:14.986Z",
+        "updatedAt": "2015-02-24T22:52:14.986Z"
+      },
+      {
+        "projectId": null,
+        "taskId": null,
+        "tagId": 7,
+        "userId": 2,
+        "id": 4,
+        "createdAt": "2015-02-24T22:52:15.239Z",
+        "updatedAt": "2015-02-24T22:52:15.239Z"
+      },
+      {
+        "projectId": null,
+        "taskId": null,
+        "tagId": 11,
+        "userId": 3,
+        "id": 5,
+        "createdAt": "2015-02-24T22:52:15.478Z",
+        "updatedAt": "2015-02-24T22:52:15.478Z"
+      },
+      {
+        "projectId": null,
+        "taskId": null,
+        "tagId": 6,
+        "userId": 3,
+        "id": 6,
+        "createdAt": "2015-02-24T22:52:15.727Z",
+        "updatedAt": "2015-02-24T22:52:15.727Z"
+      },
+      {
+        "projectId": null,
+        "taskId": null,
+        "tagId": 14,
+        "userId": 4,
+        "id": 7,
+        "createdAt": "2015-02-24T22:52:15.988Z",
+        "updatedAt": "2015-02-24T22:52:15.988Z"
+      },
+      {
+        "projectId": null,
+        "taskId": null,
+        "tagId": 8,
+        "userId": 4,
+        "id": 8,
+        "createdAt": "2015-02-24T22:52:16.240Z",
+        "updatedAt": "2015-02-24T22:52:16.240Z"
+      },
+      {
+        "projectId": 1,
+        "taskId": null,
+        "tagId": 1,
+        "id": 9,
+        "createdAt": "2015-02-24T22:52:17.469Z",
+        "updatedAt": "2015-02-24T22:52:17.469Z"
+      },
+      {
+        "projectId": 1,
+        "taskId": null,
+        "tagId": 2,
+        "id": 10,
+        "createdAt": "2015-02-24T22:52:17.473Z",
+        "updatedAt": "2015-02-24T22:52:17.473Z"
+      }
+    ],
+    "tagentity": [
+      {
+        "type": "skill",
+        "name": "Writing",
+        "id": 1,
+        "createdAt": "2015-02-24T22:52:13.111Z",
+        "updatedAt": "2015-02-24T22:52:13.111Z"
+      },
+      {
+        "type": "skill",
+        "name": "Social Media",
+        "id": 2,
+        "createdAt": "2015-02-24T22:52:13.192Z",
+        "updatedAt": "2015-02-24T22:52:13.192Z"
+      },
+      {
+        "type": "skill",
+        "name": "UX",
+        "id": 3,
+        "createdAt": "2015-02-24T22:52:13.273Z",
+        "updatedAt": "2015-02-24T22:52:13.273Z"
+      },
+      {
+        "type": "topic",
+        "name": "Health",
+        "id": 4,
+        "createdAt": "2015-02-24T22:52:13.355Z",
+        "updatedAt": "2015-02-24T22:52:13.355Z"
+      },
+      {
+        "type": "topic",
+        "name": "Education",
+        "id": 5,
+        "createdAt": "2015-02-24T22:52:13.438Z",
+        "updatedAt": "2015-02-24T22:52:13.438Z"
+      },
+      {
+        "type": "agency",
+        "name": "USDA",
+        "id": 6,
+        "createdAt": "2015-02-24T22:52:13.519Z",
+        "updatedAt": "2015-02-24T22:52:13.519Z"
+      },
+      {
+        "type": "agency",
+        "name": "OSTP",
+        "id": 7,
+        "createdAt": "2015-02-24T22:52:13.607Z",
+        "updatedAt": "2015-02-24T22:52:13.607Z"
+      },
+      {
+        "type": "agency",
+        "name": "GSA",
+        "id": 8,
+        "createdAt": "2015-02-24T22:52:13.689Z",
+        "updatedAt": "2015-02-24T22:52:13.689Z"
+      },
+      {
+        "type": "agency",
+        "name": "Dept of Education",
+        "id": 9,
+        "createdAt": "2015-02-24T22:52:13.781Z",
+        "updatedAt": "2015-02-24T22:52:13.781Z"
+      },
+      {
+        "type": "agency",
+        "name": "National Parks Service",
+        "id": 10,
+        "createdAt": "2015-02-24T22:52:13.867Z",
+        "updatedAt": "2015-02-24T22:52:13.867Z"
+      },
+      {
+        "type": "location",
+        "name": "DC",
+        "id": 11,
+        "createdAt": "2015-02-24T22:52:13.954Z",
+        "updatedAt": "2015-02-24T22:52:13.954Z"
+      },
+      {
+        "type": "location",
+        "name": "GSA HQ, 1800 F St, Washington, DC",
+        "id": 12,
+        "createdAt": "2015-02-24T22:52:14.036Z",
+        "updatedAt": "2015-02-24T22:52:14.036Z"
+      },
+      {
+        "type": "location",
+        "name": "The White House, South Court",
+        "id": 13,
+        "createdAt": "2015-02-24T22:52:14.120Z",
+        "updatedAt": "2015-02-24T22:52:14.120Z"
+      },
+      {
+        "type": "location",
+        "name": "San Francisco, CA",
+        "id": 14,
+        "createdAt": "2015-02-24T22:52:14.204Z",
+        "updatedAt": "2015-02-24T22:52:14.204Z"
+      }
+    ],
+    "task": [
+      {
+        "state": "open",
+        "userId": 3,
+        "projectId": 1,
+        "title": "Validate USDA Data",
+        "description": "Some addresses in the USDA Meat & Poultry Inspection Directory need validating and correcting to ensure they can be leveraged for geospatial mapping. You will determine if the address is suitable for mapping or mailing. Get a quick intro to geo-spatial analysis and help make food inspection more efficient.",
+        "publishedAt": "2015-02-24T22:52:17.210Z",
+        "id": 1,
+        "createdAt": "2015-02-24T22:52:17.210Z",
+        "updatedAt": "2015-02-24T22:52:17.210Z"
+      }
+    ],
+    "midas_user": [
+      {
+        "username": "kids@test.gov",
+        "name": "Tammy Craig",
+        "title": "Social Media Director",
+        "bio": null,
+        "photoUrl": null,
+        "isAdmin": false,
+        "disabled": true,
+        "passwordAttempts": 0,
+        "id": 1,
+        "createdAt": "2015-02-24T22:52:11.801Z",
+        "updatedAt": "2015-02-24T22:52:18.487Z"
+      },
+      {
+        "username": "pran@test.gov",
+        "name": "Pran Mhasalkar",
+        "title": "Special Advisor",
+        "bio": null,
+        "photoUrl": null,
+        "isAdmin": false,
+        "disabled": true,
+        "passwordAttempts": 0,
+        "id": 2,
+        "createdAt": "2015-02-24T22:52:12.215Z",
+        "updatedAt": "2015-02-24T22:52:18.700Z"
+      },
+      {
+        "username": "alan@test.gov",
+        "name": "Alan Barret",
+        "title": "Deputy Secretary",
+        "bio": null,
+        "photoUrl": null,
+        "isAdmin": false,
+        "disabled": false,
+        "passwordAttempts": 0,
+        "id": 3,
+        "createdAt": "2015-02-24T22:52:12.577Z",
+        "updatedAt": "2015-02-24T22:52:18.155Z"
+      },
+      {
+        "username": "ned@gameofthrones.com",
+        "name": "Eddard Stark",
+        "title": "Lord of Winterfell and Warden of the North",
+        "bio": null,
+        "photoUrl": null,
+        "isAdmin": false,
+        "disabled": false,
+        "passwordAttempts": 0,
+        "id": 4,
+        "createdAt": "2015-02-24T22:52:12.915Z",
+        "updatedAt": "2015-02-24T22:52:18.707Z"
+      }
+    ],
+    "userauth": [],
+    "useremail": [
+      {
+        "userId": 1,
+        "email": "kids@test.gov",
+        "isPrimary": false,
+        "isVerified": false,
+        "id": 1,
+        "createdAt": "2015-02-24T22:52:11.809Z",
+        "updatedAt": "2015-02-24T22:52:11.809Z"
+      },
+      {
+        "userId": 2,
+        "email": "pran@test.gov",
+        "isPrimary": false,
+        "isVerified": false,
+        "id": 2,
+        "createdAt": "2015-02-24T22:52:12.221Z",
+        "updatedAt": "2015-02-24T22:52:12.221Z"
+      },
+      {
+        "userId": 3,
+        "email": "alan@test.gov",
+        "isPrimary": false,
+        "isVerified": false,
+        "id": 3,
+        "createdAt": "2015-02-24T22:52:12.583Z",
+        "updatedAt": "2015-02-24T22:52:12.583Z"
+      },
+      {
+        "userId": 4,
+        "email": "ned@gameofthrones.com",
+        "isPrimary": false,
+        "isVerified": false,
+        "id": 4,
+        "createdAt": "2015-02-24T22:52:12.922Z",
+        "updatedAt": "2015-02-24T22:52:12.922Z"
+      }
+    ],
+    "usernotification": [],
+    "userpassword": [
+      {
+        "userId": 1,
+        "password": "$2a$10$PmIGFyOqsTRS.N.Sjn/ekODss9.fkzu8j8/nok64B.8kx9L6y.mK2",
+        "id": 1,
+        "createdAt": "2015-02-24T22:52:11.805Z",
+        "updatedAt": "2015-02-24T22:52:11.805Z"
+      },
+      {
+        "userId": 2,
+        "password": "$2a$10$xJWsyaX82ZXggaRpN3A15OYAbq1Hjts8VI7aYhnJfmxaHFSZefWjW",
+        "id": 2,
+        "createdAt": "2015-02-24T22:52:12.217Z",
+        "updatedAt": "2015-02-24T22:52:12.217Z"
+      },
+      {
+        "userId": 3,
+        "password": "$2a$10$mGlHGgYO1hO7rkUzfPowV.3cuGpY5jgxU/b2XllZHnL0Qgk9bZ7ti",
+        "id": 3,
+        "createdAt": "2015-02-24T22:52:12.580Z",
+        "updatedAt": "2015-02-24T22:52:12.580Z"
+      },
+      {
+        "userId": 4,
+        "password": "$2a$10$BPRElAcx4Ifj8LZ1wa.cT.9018LK1Wqnvbp2nNp7NbTiqhZ6Efn.i",
+        "id": 4,
+        "createdAt": "2015-02-24T22:52:12.917Z",
+        "updatedAt": "2015-02-24T22:52:12.917Z"
+      }
+    ],
+    "userpasswordreset": [],
+    "usersetting": [],
+    "volunteer": []
+  },
+  "schema": {
+    "attachment": {
+      "fileId": {
+        "type": "integer"
+      },
+      "projectId": {
+        "type": "integer"
+      },
+      "taskId": {
+        "type": "integer"
+      },
+      "userId": {
+        "type": "integer"
+      },
+      "id": {
+        "type": "integer",
+        "autoIncrement": true,
+        "primaryKey": true,
+        "unique": true
+      },
+      "createdAt": {
+        "type": "datetime"
+      },
+      "updatedAt": {
+        "type": "datetime"
+      }
+    },
+    "comment": {
+      "topic": {
+        "type": "boolean",
+        "defaultsTo": false
+      },
+      "projectId": {
+        "type": "integer"
+      },
+      "taskId": {
+        "type": "integer"
+      },
+      "parentId": {
+        "type": "integer"
+      },
+      "userId": {
+        "type": "integer"
+      },
+      "value": {
+        "type": "string"
+      },
+      "id": {
+        "type": "integer",
+        "autoIncrement": true,
+        "primaryKey": true,
+        "unique": true
+      },
+      "createdAt": {
+        "type": "datetime"
+      },
+      "updatedAt": {
+        "type": "datetime"
+      }
+    },
+    "delivery": {
+      "notificationId": {
+        "type": "integer"
+      },
+      "deliveryDate": {
+        "type": "datetime"
+      },
+      "deliveryType": {
+        "type": "string"
+      },
+      "content": {
+        "type": "string"
+      },
+      "isDelivered": {
+        "type": "boolean",
+        "defaultsTo": false
+      },
+      "isActive": {
+        "type": "boolean",
+        "defaultsTo": true
+      },
+      "id": {
+        "type": "integer",
+        "autoIncrement": true,
+        "primaryKey": true,
+        "unique": true
+      },
+      "createdAt": {
+        "type": "datetime"
+      },
+      "updatedAt": {
+        "type": "datetime"
+      }
+    },
+    "event": {
+      "status": {
+        "type": "string",
+        "defaultsTo": "CONFIRMED"
+      },
+      "uuid": {
+        "type": "string"
+      },
+      "title": {
+        "type": "string"
+      },
+      "description": {
+        "type": "string"
+      },
+      "start": {
+        "type": "datetime"
+      },
+      "end": {
+        "type": "datetime"
+      },
+      "location": {
+        "type": "string"
+      },
+      "userId": {
+        "type": "integer"
+      },
+      "projectId": {
+        "type": "integer"
+      },
+      "id": {
+        "type": "integer",
+        "autoIncrement": true,
+        "primaryKey": true,
+        "unique": true
+      },
+      "createdAt": {
+        "type": "datetime"
+      },
+      "updatedAt": {
+        "type": "datetime"
+      }
+    },
+    "eventrsvp": {
+      "eventId": {
+        "type": "integer"
+      },
+      "userId": {
+        "type": "integer"
+      },
+      "id": {
+        "type": "integer",
+        "autoIncrement": true,
+        "primaryKey": true,
+        "unique": true
+      },
+      "createdAt": {
+        "type": "datetime"
+      },
+      "updatedAt": {
+        "type": "datetime"
+      }
+    },
+    "file": {
+      "userId": {
+        "type": "integer"
+      },
+      "name": {
+        "type": "string"
+      },
+      "isPrivate": {
+        "type": "boolean",
+        "defaultsTo": false
+      },
+      "mimeType": {
+        "type": "string"
+      },
+      "size": {
+        "type": "integer"
+      },
+      "data": {
+        "type": "binary"
+      },
+      "id": {
+        "type": "integer",
+        "autoIncrement": true,
+        "primaryKey": true,
+        "unique": true
+      },
+      "createdAt": {
+        "type": "datetime"
+      },
+      "updatedAt": {
+        "type": "datetime"
+      }
+    },
+    "like": {
+      "projectId": {
+        "type": "integer"
+      },
+      "taskId": {
+        "type": "integer"
+      },
+      "targetId": {
+        "type": "integer"
+      },
+      "userId": {
+        "type": "integer"
+      },
+      "id": {
+        "type": "integer",
+        "autoIncrement": true,
+        "primaryKey": true,
+        "unique": true
+      },
+      "createdAt": {
+        "type": "datetime"
+      },
+      "updatedAt": {
+        "type": "datetime"
+      }
+    },
+    "notification": {
+      "callerId": {
+        "type": "integer"
+      },
+      "callerType": {
+        "type": "string"
+      },
+      "triggerGuid": {
+        "type": "string"
+      },
+      "action": {
+        "type": "string"
+      },
+      "audience": {
+        "type": "string"
+      },
+      "recipientId": {
+        "type": "integer"
+      },
+      "createdDate": {
+        "type": "datetime"
+      },
+      "localParams": {
+        "type": "string"
+      },
+      "globalParams": {
+        "type": "string"
+      },
+      "isActive": {
+        "type": "boolean",
+        "defaultsTo": true
+      },
+      "id": {
+        "type": "integer",
+        "autoIncrement": true,
+        "primaryKey": true,
+        "unique": true
+      },
+      "createdAt": {
+        "type": "datetime"
+      },
+      "updatedAt": {
+        "type": "datetime"
+      }
+    },
+    "project": {
+      "state": {
+        "type": "string",
+        "defaultsTo": "open"
+      },
+      "title": {
+        "type": "string"
+      },
+      "description": {
+        "type": "string"
+      },
+      "coverId": {
+        "type": "integer"
+      },
+      "id": {
+        "type": "integer",
+        "autoIncrement": true,
+        "primaryKey": true,
+        "unique": true
+      },
+      "createdAt": {
+        "type": "datetime"
+      },
+      "updatedAt": {
+        "type": "datetime"
+      }
+    },
+    "projectowner": {
+      "projectId": {
+        "type": "integer"
+      },
+      "userId": {
+        "type": "integer"
+      },
+      "id": {
+        "type": "integer",
+        "autoIncrement": true,
+        "primaryKey": true,
+        "unique": true
+      },
+      "createdAt": {
+        "type": "datetime"
+      },
+      "updatedAt": {
+        "type": "datetime"
+      }
+    },
+    "projectparticipant": {
+      "projectId": {
+        "type": "integer"
+      },
+      "userId": {
+        "type": "integer"
+      },
+      "id": {
+        "type": "integer",
+        "autoIncrement": true,
+        "primaryKey": true,
+        "unique": true
+      },
+      "createdAt": {
+        "type": "datetime"
+      },
+      "updatedAt": {
+        "type": "datetime"
+      }
+    },
+    "projecttag": {
+      "projectId": {
+        "type": "integer"
+      },
+      "tagId": {
+        "type": "integer"
+      },
+      "id": {
+        "type": "integer",
+        "autoIncrement": true,
+        "primaryKey": true,
+        "unique": true
+      },
+      "createdAt": {
+        "type": "datetime"
+      },
+      "updatedAt": {
+        "type": "datetime"
+      }
+    },
+    "tag": {
+      "projectId": {
+        "type": "integer"
+      },
+      "taskId": {
+        "type": "integer"
+      },
+      "tagId": {
+        "type": "integer"
+      },
+      "userId": {
+        "type": "integer"
+      },
+      "id": {
+        "type": "integer",
+        "autoIncrement": true,
+        "primaryKey": true,
+        "unique": true
+      },
+      "createdAt": {
+        "type": "datetime"
+      },
+      "updatedAt": {
+        "type": "datetime"
+      }
+    },
+    "tagentity": {
+      "type": {
+        "type": "string"
+      },
+      "name": {
+        "type": "string"
+      },
+      "id": {
+        "type": "integer",
+        "autoIncrement": true,
+        "primaryKey": true,
+        "unique": true
+      },
+      "createdAt": {
+        "type": "datetime"
+      },
+      "updatedAt": {
+        "type": "datetime"
+      }
+    },
+    "task": {
+      "state": {
+        "type": "string",
+        "defaultsTo": "open"
+      },
+      "userId": {
+        "type": "integer"
+      },
+      "projectId": {
+        "type": "integer"
+      },
+      "title": {
+        "type": "string"
+      },
+      "description": {
+        "type": "string"
+      },
+      "publishedAt": {
+        "type": "datetime"
+      },
+      "assignedAt": {
+        "type": "datetime"
+      },
+      "completedAt": {
+        "type": "datetime"
+      },
+      "id": {
+        "type": "integer",
+        "autoIncrement": true,
+        "primaryKey": true,
+        "unique": true
+      },
+      "createdAt": {
+        "type": "datetime"
+      },
+      "updatedAt": {
+        "type": "datetime"
+      }
+    },
+    "midas_user": {
+      "username": {
+        "type": "string"
+      },
+      "name": {
+        "type": "string"
+      },
+      "title": {
+        "type": "string"
+      },
+      "bio": {
+        "type": "string"
+      },
+      "photoId": {
+        "type": "integer"
+      },
+      "photoUrl": {
+        "type": "string"
+      },
+      "isAdmin": {
+        "type": "boolean",
+        "defaultsTo": false
+      },
+      "disabled": {
+        "type": "boolean",
+        "defaultsTo": false
+      },
+      "passwordAttempts": {
+        "type": "integer",
+        "defaultsTo": 0
+      },
+      "id": {
+        "type": "integer",
+        "autoIncrement": true,
+        "primaryKey": true,
+        "unique": true
+      },
+      "createdAt": {
+        "type": "datetime"
+      },
+      "updatedAt": {
+        "type": "datetime"
+      }
+    },
+    "userauth": {
+      "userId": {
+        "type": "integer"
+      },
+      "provider": {
+        "type": "string"
+      },
+      "providerId": {
+        "type": "string"
+      },
+      "accessToken": {
+        "type": "string"
+      },
+      "refreshToken": {
+        "type": "string"
+      },
+      "refreshTime": {
+        "type": "datetime"
+      },
+      "id": {
+        "type": "integer",
+        "autoIncrement": true,
+        "primaryKey": true,
+        "unique": true
+      },
+      "createdAt": {
+        "type": "datetime"
+      },
+      "updatedAt": {
+        "type": "datetime"
+      }
+    },
+    "useremail": {
+      "userId": {
+        "type": "integer"
+      },
+      "email": {
+        "type": "string"
+      },
+      "isPrimary": {
+        "type": "boolean",
+        "defaultsTo": false
+      },
+      "isVerified": {
+        "type": "boolean",
+        "defaultsTo": false
+      },
+      "token": {
+        "type": "string"
+      },
+      "id": {
+        "type": "integer",
+        "autoIncrement": true,
+        "primaryKey": true,
+        "unique": true
+      },
+      "createdAt": {
+        "type": "datetime"
+      },
+      "updatedAt": {
+        "type": "datetime"
+      }
+    },
+    "usernotification": {
+      "userId": {
+        "type": "integer"
+      },
+      "notificationId": {
+        "type": "integer"
+      },
+      "id": {
+        "type": "integer",
+        "autoIncrement": true,
+        "primaryKey": true,
+        "unique": true
+      },
+      "createdAt": {
+        "type": "datetime"
+      },
+      "updatedAt": {
+        "type": "datetime"
+      }
+    },
+    "userpassword": {
+      "userId": {
+        "type": "integer"
+      },
+      "password": {
+        "type": "string"
+      },
+      "id": {
+        "type": "integer",
+        "autoIncrement": true,
+        "primaryKey": true,
+        "unique": true
+      },
+      "createdAt": {
+        "type": "datetime"
+      },
+      "updatedAt": {
+        "type": "datetime"
+      }
+    },
+    "userpasswordreset": {
+      "userId": {
+        "type": "integer"
+      },
+      "token": {
+        "type": "string"
+      },
+      "id": {
+        "type": "integer",
+        "autoIncrement": true,
+        "primaryKey": true,
+        "unique": true
+      },
+      "createdAt": {
+        "type": "datetime"
+      },
+      "updatedAt": {
+        "type": "datetime"
+      }
+    },
+    "usersetting": {
+      "userId": {
+        "type": "integer"
+      },
+      "context": {
+        "type": "string"
+      },
+      "key": {
+        "type": "string"
+      },
+      "value": {
+        "type": "string"
+      },
+      "isActive": {
+        "type": "boolean",
+        "defaultsTo": true
+      },
+      "id": {
+        "type": "integer",
+        "autoIncrement": true,
+        "primaryKey": true,
+        "unique": true
+      },
+      "createdAt": {
+        "type": "datetime"
+      },
+      "updatedAt": {
+        "type": "datetime"
+      }
+    },
+    "volunteer": {
+      "taskId": {
+        "type": "integer"
+      },
+      "userId": {
+        "type": "integer"
+      },
+      "id": {
+        "type": "integer",
+        "autoIncrement": true,
+        "primaryKey": true,
+        "unique": true
+      },
+      "createdAt": {
+        "type": "datetime"
+      },
+      "updatedAt": {
+        "type": "datetime"
+      }
+    }
+  },
+  "counters": {
+    "attachment": {},
+    "comment": {
+      "id": 3
+    },
+    "delivery": {
+      "id": 7
+    },
+    "event": {},
+    "eventrsvp": {},
+    "file": {},
+    "like": {},
+    "notification": {
+      "id": 9
+    },
+    "project": {
+      "id": 2
+    },
+    "projectowner": {
+      "id": 2
+    },
+    "projectparticipant": {},
+    "projecttag": {},
+    "tag": {
+      "id": 10
+    },
+    "tagentity": {
+      "id": 14
+    },
+    "task": {
+      "id": 1
+    },
+    "midas_user": {
+      "id": 4
+    },
+    "userauth": {},
+    "useremail": {
+      "id": 4
+    },
+    "usernotification": {},
+    "userpassword": {
+      "id": 4
+    },
+    "userpasswordreset": {},
+    "usersetting": {},
+    "volunteer": {}
+  }
+}


### PR DESCRIPTION
Adds sample data for tests generated from `make demo` and truncated.
Adds tests for the following scenarios:

1. Access `/tasks`
2. `/tasks` has a list of task
3. Access task page
4. Title of task page matches link on `/tasks`

Closes #582 
