### PR TITLE
Timestamp patch

### DIFF
--- a/assets/js/backbone/apps/tasks/edit/views/task_edit_form_view.js
+++ b/assets/js/backbone/apps/tasks/edit/views/task_edit_form_view.js
@@ -211,9 +211,9 @@ define([
         var modelData = {
           title: this.$("#task-title").val(),
           description: this.$("#task-description").val(),
-          publishedAt: this.$("#publishedAt").val(),
-          assignedAt: this.$("#assignedAt").val(),
-          completedAt: this.$("#completedAt").val()
+          publishedAt: this.$("#publishedAt").val() || undefined,
+          assignedAt: this.$("#assignedAt").val() || undefined,
+          completedAt: this.$("#completedAt").val() || undefined
         };
 
         var project = this.$("#projectId").select2('data');

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "midas",
     "private": true,
-    "version": "0.2.1",
+    "version": "0.2.2",
     "description": "Innovation platform providing collaboration and crowdsourcing tools",
     "dependencies": {
         "sails": "0.10.5",


### PR DESCRIPTION
Fixes #613 

Sails Waterline ORM treats `""` (empty string) as a string instead of `undefined`, so saving empty dates fail.