### PR TITLE
[Not ready] Search / Filtering improvements

### DIFF
--- a/api/controllers/ProjectController.js
+++ b/api/controllers/ProjectController.js
@@ -72,7 +72,7 @@ module.exports = {
       processProjects( null, [] );
     }
     else {
-      Project.find({ where: { 'state': state }, sort: {'updatedAt': -1}}).exec( function (err, projects) {
+      Project.find({ where: { 'state': 'open' }, sort: {'updatedAt': -1}}).exec( function (err, projects) {
         if (err) return res.send(400, { message: i18n.t('projectAPI.errMsg.lookupPlural')});
         async.each(projects, util.addCounts, function (err) {
           return processProjects(err, projects);

--- a/api/controllers/TaskController.js
+++ b/api/controllers/TaskController.js
@@ -28,13 +28,13 @@ module.exports = {
     // Only show drafts for current user
     if (user) {
       where = { or: [{
-        state: {'!': 'draft'}
+        state: 'open'
       }, {
         state: 'draft',
         userId: user.id
       }]};
     } else {
-      where.state = {'!': 'draft'};
+      where.state = 'open';
     }
 
     // run the common task find query

--- a/assets/js/backbone/apps/browse/views/browse_main_view.js
+++ b/assets/js/backbone/apps/browse/views/browse_main_view.js
@@ -248,7 +248,10 @@ define([
         type: 'POST',
         data: JSON.stringify(data),
         dataType: 'json',
-        contentType: 'application/json'
+        contentType: 'application/json',
+        beforeSend: function(){
+          $("#browse-search-spinner").show();
+        }
       }).done(function (data) {
           // render the search results
           self.renderList(data);


### PR DESCRIPTION

In #606, the default state for a first load of Browse Task was changed to Open instead of not draft to increase responsiveness of the initial page load. Testing of the PR#606 revealed a bug where  filtering behavior was inconsistent.

This PR causes a more consistent behavior with search / filtering changes.
--New AJAX requests are fired when searches or state filters are changed.
--if at least one state filter and one search term are used, results are only shown if both  searches produce results
-- if at least one search term and no filters are used, any results in the search set  will be used unbounded by state filtering.
-- if at least one state filter and no search terms are used, any task in the specified states will be used.
-- if no state filters and no search terms are used, then no results will be displayed.

Replaces #606 
Addresses #605