### PR TITLE
Update Berkshelf.lock version of midas-cookbook.

### DIFF
--- a/chef/Berksfile.lock
+++ b/chef/Berksfile.lock
@@ -6,7 +6,7 @@ DEPENDENCIES
     revision: feed3aed1fd4ecb12bbccf0d3ac53fdd73ccf6c1
   midas
     git: https://github.com/18F/midas-cookbook.git
-    revision: 35d4b51ddee7aed5e6080d42fbbd7f079dc6f95f
+    revision: 3b187b8c284ef741ba2e4bac4d1c559a535d5123
     branch: master
   nginx
   nodejs


### PR DESCRIPTION
Provisioning a Vagrant box was failing for me because it was trying to run
the client config task, which was deleted in
d0b0563d6fa9de6d2bccfdc2dcfcc7a50e36af51 (and references nonexistent
files).