### PR TITLE
Add logging with winston

### DIFF
--- a/config/log.js
+++ b/config/log.js
@@ -1,5 +1,5 @@
 console.log('Loading... ', __filename);
-var winston = require('winston');
+//var winston = require('winston');
 /**
 * Logger configuration
 *
@@ -14,6 +14,19 @@ var winston = require('winston');
 Winston log levels are flipped from sails log levels, so using the log_level array makes it behave as expected in the sails documentation
 */
 
+/**************************************
+/**************************************
+ ***
+ ***      OVER RIDE INSTRUCTIONS
+ ***
+ **************************************
+/**************************************/
+
+/*
+to customize your logging settings add something like the following to the portion of your local.js file ABOVE where module.exports = { begins
+
+  var winston = require('winston');
+
 var log_levels = {
   silent: 6,
   error: 5,
@@ -26,14 +39,13 @@ var log_levels = {
 
 var transports = [
     new (winston.transports.File)(
-      /*This Transport controls what is written to the log file*/
       {
         level: 'verbose',
         name: 'written.log',
         silent: false,
         colorize: false,
         timestamp: true,
-        filename: "application.log",
+        filename: "application-test.log",
         maxsize: 500000,
         maxFiles: 5,
         json: false,
@@ -41,12 +53,9 @@ var transports = [
       }
     ),
     new (winston.transports.Console)(
-      /*This Transport is required to get console output, regardless of sails log level
-      *  output will be the lesser of sails log level and the transport level if they aren't equal
-      *  accordingly, transport log level shoul always be equal or lower than sails log level for readability's sake
-      */
+
       {
-        level: 'silly',
+        level: 'verbose',
         name: 'console.log',
         silent: false,
         colorize: true,
@@ -63,9 +72,58 @@ var logger = new (winston.Logger)({
   levels: log_levels
 });
 
-/* Don't forget to set the sails logging level to  a higher or equal level to what you want in the logs */
+ ************************************
+ ************************************
+ ************************************
+
+ AND THEN add a log section inside the module exports object
+    this level needs to be equal to or greater than the level you want to capture in the winston logs
+
+ log: {
+    level: 'verbose',
+    colors: false, // To get clean logs without prefixes or color codings
+    custom: logger
+  }
+*/
+
+var winston = require('winston');
+
+var log_levels = {
+  silent: 6,
+  error: 5,
+  warn: 4,
+  debug: 3,
+  info: 2,
+  verbose: 1,
+  silly: 0
+};
+
+var transports = [
+    new (winston.transports.Console)(
+      /*This Transport is required to get console output, regardless of sails log level
+      *  output will be the lesser of sails log level and the transport level if they aren't equal
+      *  accordingly, transport log level shoul always be equal or lower than sails log level for readability's sake
+      */
+      {
+        level: 'debug',
+        name: 'console.log',
+        silent: false,
+        colorize: true,
+        timestamp: true,
+        json: false,
+        handleExceptions: false
+      }
+    )
+  ];
+
+var logger = new (winston.Logger)({
+  exitOnError: false,
+  transports: transports,
+  levels: log_levels
+});
+
 module.exports.log = {
-  level: 'silly',
-  colors: false, // To get clean logs without prefixes or color codings
+  level: 'debug',
+  colors: false,
   custom: logger
 };

--- a/config/log.js
+++ b/config/log.js
@@ -1,29 +1,71 @@
 console.log('Loading... ', __filename);
-
+var winston = require('winston');
 /**
- * Logger configuration
- *
- * Configure the log level for your app, as well as the transport
- * (Underneath the covers, Sails uses Winston for logging, which
- * allows for some pretty neat custom transports/adapters for log messages)
- *
- * For more information on the Sails logger, check out:
- * http://sailsjs.org/#documentation
- */
+* Logger configuration
+*
+* Configure the log level for your app, as well as the transport
+* (Underneath the covers, Sails uses Winston for logging, which
+* allows for some pretty neat custom transports/adapters for log messages)
+*
+* For more information on the Sails logger, check out:
+* http://sailsjs.org/#documentation
+*/
+/*
+Winston log levels are flipped from sails log levels, so using the log_level array makes it behave as expected in the sails documentation
+*/
 
-module.exports = {
+var log_levels = {
+  silent: 6,
+  error: 5,
+  warn: 4,
+  debug: 3,
+  info: 2,
+  verbose: 1,
+  silly: 0
+};
 
-  // Valid `level` configs:
-  // i.e. the minimum log level to capture with sails.log.*()
-  //
-  // 'error'	: Display calls to `.error()`
-  // 'warn'	: Display calls from `.error()` to `.warn()`
-  // 'debug'	: Display calls from `.error()`, `.warn()` to `.debug()`
-  // 'info'	: Display calls from `.error()`, `.warn()`, `.debug()` to `.info()`
-  // 'verbose': Display calls from `.error()`, `.warn()`, `.debug()`, `.info()` to `.verbose()`
-  //
-  log: {
-    level: 'info'
-  }
+var transports = [
+    new (winston.transports.File)(
+      /*This Transport controls what is written to the log file*/
+      {
+        level: 'verbose',
+        name: 'written.log',
+        silent: false,
+        colorize: false,
+        timestamp: true,
+        filename: "application.log",
+        maxsize: 500000,
+        maxFiles: 5,
+        json: false,
+        handleExceptions: false
+      }
+    ),
+    new (winston.transports.Console)(
+      /*This Transport is required to get console output, regardless of sails log level
+      *  output will be the lesser of sails log level and the transport level if they aren't equal
+      *  accordingly, transport log level shoul always be equal or lower than sails log level for readability's sake
+      */
+      {
+        level: 'silly',
+        name: 'console.log',
+        silent: false,
+        colorize: true,
+        timestamp: true,
+        json: false,
+        handleExceptions: false
+      }
+    )
+  ];
 
+var logger = new (winston.Logger)({
+  exitOnError: false,
+  transports: transports,
+  levels: log_levels
+});
+
+/* Don't forget to set the sails logging level to  a higher or equal level to what you want in the logs */
+module.exports.log = {
+  level: 'silly',
+  colors: false, // To get clean logs without prefixes or color codings
+  custom: logger
 };

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "timepicker": "jonthornton/jquery-timepicker#1.2.15",
     "uglifyify": "^3.0.1",
     "underscore": "^1.8.2",
-    "validator": "3.4.0"
+    "validator": "3.4.0",
+    "winston": "^0.9.0"
   },
   "devDependencies": {
     "casper-chai": "^0.2.1",


### PR DESCRIPTION
Basic logging with Winston. This should catch all current logging except the debug info thrown by i18n.

To use, you need to **npm install winston**

A couple of notes:
1) Winston uses different logging levels than sails (they are flipped), so the log_levels variable addresses that
2) Sails logging level (on line 68 of log.js) is the superset of available levels for other transports
3) The transport.Console is required to push info to the console and it will use the lesser of it's logging level and the sails logging level. Without it, you will see no logging information in the console.
4)Multiple transports of the same type can be created (if you wanted to write different levels to different files for instance) but they MUST have different **name** attributes or an error will be thrown.
5) The default log file needs to be given the appropriate full path when deployed.

Addresses #660 