### PR TITLE
Small setup improvements -- nvm to handle nodejs 0.10 dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ chef/cookbooks/*
 *~
 *#
 *.bak
+*.swp
 
 .DS_STORE
 .tmp

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -28,9 +28,14 @@ Start the postgres console acting on the midas database with: `psql midas`
     ALTER SCHEMA public OWNER TO midas;
     \q
 
-Then back to the command-line, install node.js:
+Install node.js. As of Feb 2015 Node.js has moved to 0.12 for its stable version. But many dependencies, especially native compiled packages, don't work with 0.10 yet. So consider running Node.js 0.10.  Consider using [nvm](https://github.com/creationix/nvm) to manage Node versions. Once installed and sourced into your environment nvm can handle manage versions. 
 
-    brew install nodejs
+So back to the command line. We assume that nvm is installed and set up
+(added to `.bashrc` or equivalent).
+    
+    nvm install 0.10
+    nvm alias default 0.10
+    nvm version             # should be something like v0.10.38
 
 Then follow platform-independent steps below starting at [clone the git repository](#clone-the-git-repository).
 


### PR DESCRIPTION
amend INSTALL: use nvm for installing node

Now that nodejs has moved on to 0.12 the default instructions (brew install nodejs) are no longer what you want. Midas depends on 0.10, for the time being at least. Instead of fragile instructions on versioning, recommend managing versions with nvm instead.

While in here, ignore vi temp files (*.swp).