### PR TITLE
Add tag when clicking outside the input field

### DIFF
--- a/assets/js/backbone/components/tag_factory.js
+++ b/assets/js/backbone/components/tag_factory.js
@@ -104,6 +104,7 @@ TagFactory = BaseComponent.extend({
           placeholder: "Start typing to select a "+options.type,
           minimumInputLength: 2,
           multiple: true,
+          selectOnBlur: true,
           width: options.width || "500px",
           tokenSeparators: options.tokenSeparators || [],
           formatResult: function (obj, container, query) {


### PR DESCRIPTION
This PR fixes bug #313. When clicking outside the tag selection field, add the tag instead of discarding it.