### PR TITLE
Click on opportunity state label changes the radio

### DIFF
--- a/assets/js/backbone/apps/tasks/show/templates/change_state_template.html
+++ b/assets/js/backbone/apps/tasks/show/templates/change_state_template.html
@@ -2,12 +2,12 @@
 	<p>Please select the new state for the opportunity. The current state is checked and the available states are:
 		<ul style='list-style-type:none'>
 			<% _.each(states, function (t) { %>
-				<li><input type='radio' name='opportunityState' value='<%- t.value %>'
+				<li><label><input type='radio' name='opportunityState' value='<%- t.value %>'
 					<% if ( t.value == model.attributes.state ) {%>
 						<%- checked="checked" %>
 					<% } %>
-						> <%- t.label %> </li>
-					<% }); %>
+						> <%- t.label %> </label></li>
+			<% }); %>
 		</ul>
 	</p>
 </div>


### PR DESCRIPTION
Simple UX fix. The labels next to the radio buttons should be clickable.

![state](https://cloud.githubusercontent.com/assets/1919681/6883085/5965ca1e-d574-11e4-814c-9132c420a428.png)
