### PR TITLE
Don't migrate the file table automatically

### DIFF
--- a/api/models/File.js
+++ b/api/models/File.js
@@ -24,6 +24,12 @@ module.exports = {
     size: 'INTEGER',
     // Raw binary file data
     data: 'BINARY'
-  }
+  },
+
+  // Don't migrate this table automatically in development because the
+  // binary file data can get corrupted when it is extracted then
+  // reinserted into the database. Any changes to this table have to be
+  // migrated manually
+  migrate: 'safe'
 
 };


### PR DESCRIPTION
This PR fixes #589 by never dropping and recreating the file table when the development server is started.

Something gets messed up in the extraction and re-insertion of the binary data during the automatic migration.

The real fix would be to dig deep in the database adapter and figure out what's going on, but this workaround is good enough since the file table is not likely to change often and thus need to be migrated in development.