### PR TITLE
The comment input should be full width

### DIFF
--- a/assets/js/backbone/apps/comments/new/templates/comment_form_template.html
+++ b/assets/js/backbone/apps/comments/new/templates/comment_form_template.html
@@ -7,7 +7,7 @@
 </div>
 <div class="row">
   <div class="col-lg-12 ">
-    <form action="" class="form-inline comment-submit <% if (form.topic) { %>comment-form-topic<% } %>" role="form" data-depth="<%= form.depth %>">
+    <form action="" class="comment-submit <% if (form.topic) { %>comment-form-topic<% } %>" role="form" data-depth="<%= form.depth %>">
       <div class="input-group">
         <div class="comment-input form-control input-sm" contentEditable="true"></div>
         <span class="input-group-btn">


### PR DESCRIPTION
While I realize that you have the hierachy of comments in there right now and the change to non-nested comments in #687 may not something you want to do right now, I still want to submit this UI fix for the width of the comment box.

![comment field](https://cloud.githubusercontent.com/assets/1919681/6910966/6bfad83a-d728-11e4-9e20-cc2be4471760.png)

I still think that a simpler comment system would help in the long run (I'm not sure I would know in which of the 3 boxes I should write a comment in the picture above).