### PR TITLE
Admin csv export for users and tasks

### DIFF
--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -9,6 +9,7 @@ var _ = require('underscore');
 var bcrypt = require('bcrypt');
 var projUtils = require('../services/utils/project');
 var taskUtils = require('../services/utils/task');
+var exportUtil = require('../services/utils/export');
 var tagUtils = require('../services/utils/tag');
 var userUtils = require('../services/utils/user');
 var validator = require('validator');
@@ -396,5 +397,26 @@ module.exports = {
     });
 
   },
+
+  export: function (req, resp) {
+    User.find().exec(function (err, users) {
+      if (err) {
+        sails.log.error("user query error. " + err);
+        resp.send(400, {message: 'An error occurred while looking up users.', error: err});
+        return;
+      }
+      sails.log.debug('user export: found %s', users.length);
+      exportUtil.renderCSV(User, users, function (err, rendered) {
+        if (err) {
+          sails.log.error("user export render error. " + err);
+          resp.send(400, {message: 'An error occurred while rendering user list.', error: err});
+          return;
+        }
+        resp.set('Content-Type', 'text/csv');
+        resp.set('Content-disposition', 'attachment; filename=users.csv');
+        resp.send(200, rendered);
+      });
+    });
+  }
 
 };

--- a/api/models/Task.js
+++ b/api/models/Task.js
@@ -3,6 +3,7 @@
     -> model
 ---------------------*/
 var noteUtils = require('../services/notifications/manager');
+var exportUtils = require('../services/utils/export');
 
 module.exports = {
 
@@ -38,6 +39,17 @@ module.exports = {
         }
         return false;
     }
+  },
+
+  exportFormat: {
+    'project_id': 'projectId',
+    'name': {field: 'title', filter: exportUtils.nullToEmptyString},
+    'description': {field: 'description', filter: exportUtils.nullToEmptyString},
+    'created_date': {field: 'createdAt', filter: exportUtils.excelDateFormat},
+    'published_date': {field: 'publishedAt', filter: exportUtils.excelDateFormat},
+    'assigned_date': {field: 'createdAt', filter: exportUtils.excelDateFormat},
+    'creator_name': {field: 'creator_name', filter: exportUtils.nullToEmptyString},
+    'signups': 'signups'
   },
 
   beforeUpdate: function(values, done) {

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -6,6 +6,8 @@
  *
  */
 
+var exportUtils = require('../services/utils/export');
+
 module.exports = {
   tableName: 'midas_user',
   attributes: {
@@ -45,6 +47,17 @@ module.exports = {
       type: 'INTEGER',
       defaultsTo: 0
     }
+  },
+
+  // TODO: add more fields, likely driven off subqueries
+  exportFormat: {
+    'user_id': 'id',
+    'name': {field: 'name', filter: exportUtils.nullToEmptyString},
+    'username': {field: 'username', filter: exportUtils.nullToEmptyString},
+    'title': {field: 'title', filter: exportUtils.nullToEmptyString},
+    'bio': {field: 'bio', filter: exportUtils.nullToEmptyString},
+    'isAdmin': 'isAdmin',
+    'disabled': 'disabled'
   }
 
 };

--- a/api/services/utils/export.js
+++ b/api/services/utils/export.js
@@ -1,0 +1,64 @@
+var _ = require('underscore');
+var json2csv = require('json2csv');
+var moment = require('moment')
+
+module.exports = {
+
+  /**
+   * Given a set of records, render to an string in CSV format. Includes column
+   * headers. Use json2csv module to take care of escapes and such.
+   *
+   * @param model -- an exportFormat object to describe what list to output. Each
+   *        field maps the output column to the input field. If the input field is
+   *        a string then it's a simple fetch, if it's an object itself then it should
+   *        have a field member for the fetch, and a format field for the function to
+   *        apply to that field.
+   * @param records -- array of records to dump out
+   * @param done(error, buffer) -- callback. if error then message in first
+   *        parameter, if OK then error should be null and rendered result in buffer.
+   */
+  renderCSV: function (model, records, done) {
+    var output = "";
+    var fieldNames = _.keys(model.exportFormat);
+    var fields = _.values(model.exportFormat);
+
+    // clean up records
+    fields.forEach(function (field, fIndex, fields) {
+      if (typeof(field) === "object") {
+        records.forEach(function (rec, rIndex, records) {
+          records[rIndex][field.field] = field.filter.call(this, rec[field.field]);
+        });
+        fields[fIndex] = field.field;
+      }
+    });
+
+    json2csv({
+      data: records,
+      fields: fields,
+      fieldNames: fieldNames
+    }, function (err, csv) {
+      if (err) {
+        done(err);
+      }
+      output += csv + "\n";
+    });
+    done(null, output);
+  },
+
+  /**
+   * Format a date as a string that imports nicely into Excel. Uses the nice momentjs
+   * library to do the heavy lifting.
+   */
+  excelDateFormat: function (date) {
+    return moment(date).format("YYYY-MM-DD HH:mm:ss")
+  },
+
+  /**
+   * By default json2csv prints nulls as "null" instead of an empty string, which looks ugly
+   * in reports. This filter takes care of that.
+   */
+  nullToEmptyString: function (str) {
+    return str ? str : "";
+  }
+
+};

--- a/assets/js/backbone/apps/admin/templates/admin_task_template.html
+++ b/assets/js/backbone/apps/admin/templates/admin_task_template.html
@@ -34,6 +34,15 @@
                 Completed: <%- completed.length %>
               </a>
             </li>
+
+            <!-- Export button -->
+            <div class="export-button pull-right tip" data-toggle="tooltip" data-placement="left"
+                 title="Download list of tasks as a comma-separated file ready for import into Excel">
+              <a href="/api/task/export">
+                <i class="fa fa-download"></i>
+              </a>
+            </div>
+
           </ul>
 
           <!-- Tab panes -->
@@ -41,85 +50,85 @@
             <div role="tabpanel" class="tab-pane" id="drafts">
               <ul class="metrics">
                 <% _(drafts).forEach(function(task) { %>
-                  <li>
-                    <a href="/tasks/<%- task.id %>"><%- task.title %></a>,
-                    <a href="/profile/<%- task.user.id %>"><%- task.user.name || task.user.username %></a>
-                    <% if (task.volunteers.length) { %>
-                    <p>Sign-ups:
-                      <% _(task.volunteers).forEach(function(vol) { %>
-                        <a href="/profile/<%- task.user.id %>"><%- vol.user.name || vol.user.username %></a>
-                      <% }); %>
-                    </p>
-                    <% } %>
-                  </li>
+                <li>
+                  <a href="/tasks/<%- task.id %>"><%- task.title %></a>,
+                  <a href="/profile/<%- task.user.id %>"><%- task.user.name || task.user.username %></a>
+                  <% if (task.volunteers.length) { %>
+                  <p>Sign-ups:
+                    <% _(task.volunteers).forEach(function(vol) { %>
+                    <a href="/profile/<%- task.user.id %>"><%- vol.user.name || vol.user.username %></a>
+                    <% }); %>
+                  </p>
+                  <% } %>
+                </li>
                 <% }); %>
               </ul>
             </div>
             <div role="tabpanel" class="tab-pane active" id="open">
               <ul class="metrics">
                 <% _(open).forEach(function(task) { %>
-                  <li>
-                    <a href="/tasks/<%- task.id %>"><%- task.title %></a>,
-                    <a href="/profile/<%- task.user.id %>"><%- task.user.name || task.user.username %></a>
-                    <% if (task.volunteers.length) { %>
-                    <p>Sign-ups:
-                      <% _(task.volunteers).forEach(function(vol) { %>
-                        <a href="/profile/<%- task.user.id %>"><%- vol.user.name || vol.user.username %></a>
-                      <% }); %>
-                    </p>
-                    <% } %>
-                  </li>
+                <li>
+                  <a href="/tasks/<%- task.id %>"><%- task.title %></a>,
+                  <a href="/profile/<%- task.user.id %>"><%- task.user.name || task.user.username %></a>
+                  <% if (task.volunteers.length) { %>
+                  <p>Sign-ups:
+                    <% _(task.volunteers).forEach(function(vol) { %>
+                    <a href="/profile/<%- task.user.id %>"><%- vol.user.name || vol.user.username %></a>
+                    <% }); %>
+                  </p>
+                  <% } %>
+                </li>
                 <% }); %>
               </ul>
             </div>
             <div role="tabpanel" class="tab-pane" id="signups">
               <ul class="metrics">
                 <% _(withSignups).forEach(function(task) { %>
-                  <li>
-                    <a href="/tasks/<%- task.id %>"><%- task.title %></a>,
-                    <a href="/profile/<%- task.user.id %>"><%- task.user.name || task.user.username %></a>
-                    <% if (task.volunteers.length) { %>
-                      <p>Sign-ups:
-                        <% _(task.volunteers).forEach(function(vol) { %>
-                          <a href="/profile/<%- task.user.id %>"><%- vol.user.name || vol.user.username %></a>
-                        <% }); %>
-                      </p>
-                    <% } %>
-                  </li>
+                <li>
+                  <a href="/tasks/<%- task.id %>"><%- task.title %></a>,
+                  <a href="/profile/<%- task.user.id %>"><%- task.user.name || task.user.username %></a>
+                  <% if (task.volunteers.length) { %>
+                  <p>Sign-ups:
+                    <% _(task.volunteers).forEach(function(vol) { %>
+                    <a href="/profile/<%- task.user.id %>"><%- vol.user.name || vol.user.username %></a>
+                    <% }); %>
+                  </p>
+                  <% } %>
+                </li>
                 <% }); %>
               </ul>
             </div>
             <div role="tabpanel" class="tab-pane" id="assigned">
               <ul class="metrics">
                 <% _(assigned).forEach(function(task) { %>
-                  <li>
-                    <a href="/tasks/<%- task.id %>"><%- task.title %></a>,
-                    <a href="/profile/<%- task.user.id %>"><%- task.user.name || task.user.username %></a>
-                    <% if (task.volunteers.length) { %>
-                      <p>Sign-ups:
-                        <% _(task.volunteers).forEach(function(vol) { %>
-                          <a href="/profile/<%- task.user.id %>"><%- vol.user.name || vol.user.username %></a>
-                        <% }); %>
-                      </p>
-                    <% } %>
-                  </li>
+                <li>
+                  <a href="/tasks/<%- task.id %>"><%- task.title %></a>,
+                  <a href="/profile/<%- task.user.id %>"><%- task.user.name || task.user.username %></a>
+                  <% if (task.volunteers.length) { %>
+                  <p>Sign-ups:
+                    <% _(task.volunteers).forEach(function(vol) { %>
+                    <a href="/profile/<%- task.user.id %>"><%- vol.user.name || vol.user.username %></a>
+                    <% }); %>
+                  </p>
+                  <% } %>
+                </li>
                 <% }); %>
               </ul>
             </div>
             <div role="tabpanel" class="tab-pane" id="completed">
               <ul class="metrics">
                 <% _(completed).forEach(function(task) { %>
-                  <li>
-                    <a href="/tasks/<%- task.id %>"><%- task.title %></a>,
-                    <a href="/profile/<%- task.user.id %>"><%- task.user.name || task.user.username %></a>
-                    <% if (task.volunteers.length) { %>
-                      <p>Sign-ups:
-                        <% _(task.volunteers).forEach(function(vol) { %>
-                          <a href="/profile/<%- task.user.id %>"><%- vol.user.name || vol.user.username %></a>
-                        <% }); %>
-                      </p>
-                    <% } %>
-                  </li>
+                <li>
+                  <a href="/tasks/<%- task.id %>"><%- task.title %></a>,
+                  <a href="/profile/<%- task.user.id %>"><%- task.user.name || task.user.username %></a>
+                  <% if (task.volunteers.length) { %>
+                  <p>Sign-ups:
+                    <% _(task.volunteers).forEach(function(vol) { %>
+                    <a href="/profile/<%- task.user.id %>"><%- vol.user.name || vol.user.username %></a>
+                    <% }); %>
+                  </p>
+                  <% } %>
+                </li>
                 <% }); %>
               </ul>
             </div>

--- a/assets/js/backbone/apps/admin/templates/admin_user_template.html
+++ b/assets/js/backbone/apps/admin/templates/admin_user_template.html
@@ -6,18 +6,26 @@
     <div class="row">
       <div class="col-lg-8 col-md-7 col-sm-5 sm-nopadding md-nopadding">
 
-      <form class="form-inline fullwidth" role="form">
-        <div class="form-group fullwidth">
-          <label class="sr-only" for="user-filter">Filter</label>
-          <input type="text" class="form-control fullwidth" id="user-filter" placeholder="Filter">
-        </div>
-      </form>
+        <form class="form-inline fullwidth" role="form">
+          <div class="form-group fullwidth">
+            <label class="sr-only" for="user-filter">Filter</label>
+            <input type="text" class="form-control fullwidth" id="user-filter" placeholder="Filter">
+          </div>
+        </form>
 
       </div>
+
       <div class="col-lg-4 col-md-5 col-sm-7 sm-nopadding md-nopadding-right">
+        <div class="export-button pull-left tip" data-toggle="tooltip" data-placement="bottom"
+             title="Download list of all users as a comma-separated file ready for import into Excel">
+          <a href="/api/user/export">
+            <i class="fa fa-download"></i>
+          </a>
+        </div>
         <div class="pull-right" id="user-page">
         </div>
       </div>
+
     </div>
     <div class="row">
       <div class="col-md-12 sm-nopadding md-nopadding">

--- a/assets/js/backbone/apps/admin/views/admin_task_view.js
+++ b/assets/js/backbone/apps/admin/views/admin_task_view.js
@@ -27,6 +27,7 @@ var AdminTaskView = Backbone.View.extend({
         var template = _.template(AdminTaskTemplate)(data);
         self.$el.html(template);
         self.$el.show();
+        $('.tip').tooltip();
       },
       error: function (xhr, status, error) {
         self.handleError(self, xhr, status, error);

--- a/assets/js/backbone/apps/admin/views/admin_user_view.js
+++ b/assets/js/backbone/apps/admin/views/admin_user_view.js
@@ -116,6 +116,7 @@ var AdminUserView = Backbone.View.extend({
       success: function (data) {
         self.data = data;
         self.renderUsers(self, data);
+        $('.tip').tooltip();
       },
       error: function (xhr, status, error) {
         self.handleError(self, xhr, status, error);

--- a/assets/styles/application.css
+++ b/assets/styles/application.css
@@ -1665,3 +1665,12 @@ ul.task-tags > li {
     line-height: 96px;
   }
 }
+
+.export-button {
+  font-size: 1.5em;
+  line-height: 34px;
+}
+
+.nav-tabs > .export-button {
+  line-height: 42px;
+}

--- a/config/policies.js
+++ b/config/policies.js
@@ -48,7 +48,8 @@ module.exports.policies = {
     'disable': ['authenticated', 'requireId', 'requireUserId'],
     'enable': ['authenticated', 'requireId', 'requireUserId', 'admin'],
     'resetPassword': ['authenticated', 'requireUserId'],
-    'emailCount': ['test']
+    'emailCount': ['test'],
+    'export': ['authenticated', 'admin']
   },
 
   UserEmailController : {
@@ -162,7 +163,8 @@ module.exports.policies = {
     'findAllByProjectId': ['authenticated', 'requireId', 'project'],
     'create': ['authenticated', 'requireUserId', 'addUserId'],
     'update': ['authenticated', 'requireUserId', 'requireId', 'projectId', 'task', 'ownerOrAdmin'],
-    'destroy': ['authenticated', 'requireUserId', 'requireId', 'task', 'ownerOrAdmin']
+    'destroy': ['authenticated', 'requireUserId', 'requireId', 'task', 'ownerOrAdmin'],
+    'export': ['authenticated', 'admin']
   },
 
   AttachmentController: {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "icalendar": "0.6.5",
     "jquery.atwho": "ichord/At.js#v0.4.7",
     "jquery.caret": "ichord/Caret.js#v0.0.7",
+    "json2csv": "^2.2.1",
     "lodash": "~2.4.1",
     "marked": "^0.3.3",
     "mocha": "2.2.1",

--- a/test/api/sails/admin.test.js
+++ b/test/api/sails/admin.test.js
@@ -153,5 +153,19 @@ describe('admin:', function () {
       });
     });
 
+    it('export', function (done) {
+      request.get({
+        url: conf.url + '/user/export'
+      }, function (err, response, body) {
+        assert.equal(response.statusCode, 200);
+        var testBody = '"user_id","name","username","title","bio","isAdmin","disabled"\n' +
+            '1,"","tester1@midascrowd.com","","",false,false\n' +
+            '2,"","admin@midascrowd.com","","",true,false\n' +
+            '3,"","testreset@midascrowd.com","","",false,false\n'
+        assert.equal(body, testBody);
+        done(err);
+      });
+    });
+
   });
 });

--- a/test/api/sails/helpers/config.js
+++ b/test/api/sails/helpers/config.js
@@ -33,6 +33,18 @@ module.exports = {
     'title': 'Project Title',
     'description': 'Project Description'
   },
+  'tasks': [
+    {
+      'title': 'task1',
+      'description': 'description1',
+      'creatorId': 1
+    },
+    {
+      'title': 'task2',
+      'description': 'description2',
+      'creatorId': 1
+    }
+  ],
   'tags': [
     {
       'type': 'skill',

--- a/test/api/sails/helpers/utils.js
+++ b/test/api/sails/helpers/utils.js
@@ -1,6 +1,7 @@
 var conf = require('./config');
 var fs = require('fs');
 var request = require('request');
+var async = require('async');
 var _ = require('underscore');
 
 module.exports = {
@@ -8,6 +9,12 @@ module.exports = {
     var j = request.jar();
     var r = request.defaults({ jar: j, followRedirect: false });
     return r;
+  },
+
+  logout: function (request, cb) {
+    request.get({url: conf.url + '/auth/logout'}, function (err) {
+      return cb(err);
+    });
   },
 
   login: function (request, user, cb) {
@@ -62,6 +69,22 @@ module.exports = {
       var b = JSON.parse(body);
       cb(null, b);
     });
+  },
+
+  createTasks: function (request, outerCallback) {
+    async.each(conf.tasks,
+        function (task, innerCallback) {
+          request.post({
+            url: conf.url + '/task/create',
+            body: JSON.stringify(task)
+          }, function (err) {
+            innerCallback(err);
+          })
+        },
+        function (err) {
+          outerCallback(err);
+        }
+    );
   }
 
 };

--- a/test/api/sails/task.test.js
+++ b/test/api/sails/task.test.js
@@ -1,0 +1,81 @@
+var assert = require('chai').assert;
+var conf = require('./helpers/config');
+var utils = require('./helpers/utils');
+var request;
+
+describe('tasks:', function () {
+
+  describe('not logged in:', function () {
+    before(function (done) {
+      request = utils.init();
+      utils.logout(request, function (err) {
+        if (err) {
+          return done(err);
+        }
+        done();
+      });
+    });
+
+    it('deny export', function (done) {
+      request.get({
+        url: conf.url + '/task/export'
+      }, function (err, response) {
+        assert.equal(response.statusCode, 403);
+        done(err);
+      });
+    });
+  });
+
+  describe('not admin:', function () {
+    before(function (done) {
+      request = utils.init();
+      utils.login(request, conf.defaultUser, function (err) {
+        if (err) {
+          return done(err);
+        }
+        done();
+      });
+    });
+
+    it('deny export', function (done) {
+      request.get({
+        url: conf.url + '/task/export'
+      }, function (err, response, body) {
+        assert.equal(response.statusCode, 403);
+        done(err);
+      });
+    });
+  });
+
+  describe('admin:', function () {
+    before(function (done) {
+      request = utils.init();
+      utils.login(request, conf.adminUser, function (err) {
+        if (err) {
+          return done(err);
+        }
+        utils.createTasks(request, function (err) {
+          if (err) {
+            return done(err);
+          }
+          done(err);
+        });
+      });
+    });
+
+    it('export', function (done) {
+      request.get({
+        url: conf.url + '/task/export'
+      }, function (err, response, body) {
+        assert.equal(response.statusCode, 200);
+        var saniBody = body.replace(/\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/g, "DATE");
+        var testBody = '"project_id","name","description","created_date","published_date","assigned_date","creator_name","signups"\n,' +
+        '"task1","description1","DATE","DATE","DATE","",0\n,' +
+        '"task2","description2","DATE","DATE","DATE","",0\n';
+        assert.equal(saniBody, testBody);
+        done(err);
+      });
+    });
+  });
+
+});

--- a/test/api/sails/user.test.js
+++ b/test/api/sails/user.test.js
@@ -6,8 +6,12 @@ var _ = require('underscore');
 var request;
 
 describe('user:', function() {
-  before(function() {
+  before(function (done) {
     request = utils.init();
+    utils.logout(request, function (err) {
+      if (err) { return done(err); }
+      done();
+    });
   });
 
   it('not logged in', function(done) {
@@ -24,6 +28,15 @@ describe('user:', function() {
       // Not logged in users should get a 403
       assert.equal(response.statusCode, 403);
       done();
+    });
+  });
+  it('deny export', function (done) {
+    request.get({
+      url: conf.url + '/user/export'
+    }, function (err, response, body) {
+      // Not logged in users should get a 403
+      assert.equal(response.statusCode, 403);
+      done(err);
     });
   });
   it('register', function (done) {


### PR DESCRIPTION
Add a "download" button on the user and tasks admin pages to save a csv
format of those files. CSV file formatted for easy import into Excel by
handling null strings and formatting dates. Adds dependency on the
json2csv module to produce well-formatted csv (handles escape quoting,
etc.)

This fixes issues #667 and #668.

Some clumsiness on the task csv in how it counts volunteers to summarize
in the "signup" column. I couldn't get a groupby/count to work with the
waterline ORM, so had to resort to clunky sql and exclude that for test
cases, where the backend isn't sql-compliant.