### PR TITLE
Change migrate to safe in the development env file as default

### DIFF
--- a/config/env/development.js
+++ b/config/env/development.js
@@ -1,7 +1,10 @@
 console.log('Loading... ', __filename);
 
 // Override settings for development
+// ****NOTE**** Midas uses npm run migrate to initiate db changes
+//    4/8/2015 --  migrate alter doesn't appear to work correctly with the softdelete sails postgres fork midas uses
+//         ( it undeletes things that have been soft deleted on sails lift )
 
 module.exports.models = {
-  migrate: 'alter'
+  migrate: 'safe'
 }


### PR DESCRIPTION
Since we use **npm run migrate** for db changes and since migrate alter doesn't play nice with our sails postgres soft deletes fork, migrate alter should never be used even in development.