### PR TITLE
Issue #640: Prevent saving a profile with an empty name

### DIFF
--- a/assets/js/backbone/apps/profiles/show/templates/profile_show_template.html
+++ b/assets/js/backbone/apps/profiles/show/templates/profile_show_template.html
@@ -53,7 +53,8 @@
       <form class="form-horizontal" role="form" id="profile-form">
         <h1>
           <div class="form-group">
-            <input type="text" class="form-control input-lg" id="name" name="name" placeholder="Your Full Name" value="<% if (data.name) { %><%- data.name %><% } %>" title="Your Full Name"/>
+            <input type="text" class="form-control validate input-lg" id="name" name="name" placeholder="Your Full Name" value="<% if (data.name) { %><%- data.name %><% } %>" data-validate="empty" title="Your Full Name"/>
+            <span class="help-block error-empty" style="display:none;font-size:14px;">Please enter your full name.</span>
           </div>
         </h1>
 

--- a/assets/js/backbone/apps/profiles/show/views/profile_show_view.js
+++ b/assets/js/backbone/apps/profiles/show/views/profile_show_view.js
@@ -26,6 +26,9 @@ var ProfileShowView = Backbone.View.extend({
     "click #profile-cancel"      : "profileCancel",
     "click #like-button"         : "like",
     "keyup #name, #title, #bio"  : "fieldModified",
+    "keyup"                      : "checkName",
+    "change"                     : "checkName",
+    "blur"                       : "checkName",
     "click .removeAuth"          : "removeAuth"
   },
 
@@ -526,6 +529,15 @@ var ProfileShowView = Backbone.View.extend({
     this.model.trigger("profile:input:changed", e);
   },
 
+  checkName: function (e) {
+    var name = this.$("#name").val();
+    if (name && name !== '') {
+      $("#name").closest(".form-group").find(".help-block").hide();
+    } else {
+      $("#name").closest(".form-group").find(".help-block").show();
+    }
+  },
+
   profileCancel: function (e) {
     e.preventDefault();
     Backbone.history.navigate('profile/' + this.model.toJSON().id, { trigger: true });
@@ -538,8 +550,15 @@ var ProfileShowView = Backbone.View.extend({
 
   profileSubmit: function (e) {
     e.preventDefault();
+
+    // If the name isn't valid, don't put the save through
+    if (validate({ currentTarget: '#name' })) {
+      return;
+    }
+
     $("#profile-save, #submit").button('loading');
     setTimeout(function() { $("#profile-save, #submit").attr("disabled", "disabled") }, 0);
+
     var data = {
           name: $("#name").val(),
           title: $("#title").val(),


### PR DESCRIPTION
Add client-side validation to profile editing that prevents members from saving with an empty name. Use utilities.validator for validation.

This should address issue #640.

As far as I can tell, there is no test coverage around this part of the application. Let me know if I'm mistaken and I'll add testing for this change.