### PR TITLE
Open volunteer modal after local sign-in

### DIFF
--- a/assets/js/backbone/apps/tasks/show/controllers/task_show_controller.js
+++ b/assets/js/backbone/apps/tasks/show/controllers/task_show_controller.js
@@ -315,6 +315,7 @@ var TaskShowController = BaseView.extend({
   volunteer: function (e) {
     if (e.preventDefault) e.preventDefault();
     if (!window.cache.currentUser) {
+      window.cache.taskVolunteer = this.model.id;
       window.cache.userEvents.trigger("user:request:login");
     } else {
       var self = this;

--- a/assets/js/backbone/apps/tasks/show/views/task_item_view.js
+++ b/assets/js/backbone/apps/tasks/show/views/task_item_view.js
@@ -59,6 +59,10 @@ var TaskItemView = BaseView.extend({
       $("time.timeago").timeago();
       self.updateTaskEmail();
       self.model.trigger('task:show:render:done');
+      if (window.cache.taskVolunteer && !self.model.attributes.volunteer) {
+        $('#volunteer').click();
+        delete window.cache.taskVolunteer;
+      }
     });
   },
 


### PR DESCRIPTION
When an unauthenticated volunteer clicks the "Volunteer" button on a task, they are prompted to log in. This PR triggers the "Volunteer" modal after sign-in for local accounts and new sign-ups. It won't work for oauth accounts, as they require a persistent mechanism (captured in #724)

Resolves #637