### PR TITLE
[Not ready] Add unique constraint to User.username

### DIFF
--- a/api/models/User.js
+++ b/api/models/User.js
@@ -12,7 +12,10 @@ module.exports = {
   tableName: 'midas_user',
   attributes: {
     // Login information
-    username: 'STRING',
+    username: {
+      type: 'STRING',
+      unique: true
+    },
 
     // Core attributes about a user
     name: 'STRING',

--- a/api/services/utils/user.js
+++ b/api/services/utils/user.js
@@ -203,9 +203,21 @@ module.exports = {
             userCreateParam = userData;
           }
           User.create(userCreateParam).exec(function (err, user) {
+            var errorMessage = '';
             if (err) {
               sails.log.debug('User creation error:', err);
-              return done(null, false, { message: 'Unable to create new user. Please try again.'});
+              if (err.invalidAttributes) {
+                _.each(err.invalidAttributes, function(error) {
+                  errorMessage = errorMessage + ' ' + error.map(function(msg) {
+                    return msg.message;
+                  }).join(' ');
+                });
+              }
+              return done(null, false, {
+                message: (errorMessage) ?
+                  'Unable to create new user.' + errorMessage :
+                  'Unable to create new user. Please try again.'
+              });
             }
             sails.log.debug('User Created:', user);
             var pwObj = {

--- a/assets/js/backbone/apps/login/views/login_view.js
+++ b/assets/js/backbone/apps/login/views/login_view.js
@@ -85,7 +85,9 @@ var LoginView = Backbone.View.extend({
         $submitButton = self.$('#registration-form [type="submit"]');
     if (e.preventDefault) e.preventDefault();
 
+    if ($submitButton.prop('disabled')) return;
     $submitButton.prop('disabled', true);
+
     // validate input fields
     var validateIds = ['#rname', '#rusername', '#rpassword'];
     // Only validate terms & conditions if it is enabled
@@ -93,7 +95,7 @@ var LoginView = Backbone.View.extend({
       validateIds.push('#rterms');
     }
     var abort = false;
-    for (i in validateIds) {
+    for (var i in validateIds) {
       var iAbort = validate({ currentTarget: validateIds[i] });
       abort = abort || iAbort;
     }
@@ -127,7 +129,7 @@ var LoginView = Backbone.View.extend({
     };
     // Add in additional, optional fields
     if (this.options.login.terms.enabled === true) {
-      data['terms'] = (this.$("#rterms").val() == "on");
+      data.terms = (this.$("#rterms").val() == "on");
     }
     // Post the registration request to the server
     $.ajax({
@@ -227,7 +229,7 @@ var LoginView = Backbone.View.extend({
   checkPasswordConfirm: function (e) {
     var success = true;
     var password = this.$("#rpassword").val();
-    var confirm = this.$("#rpassword-confirm").val()
+    var confirm = this.$("#rpassword-confirm").val();
     if (password === confirm) {
       $("#rpassword-confirm").closest(".form-group").find(".help-block").hide();
     } else {

--- a/tools/postgres/migrate/6.sh
+++ b/tools/postgres/migrate/6.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Add a data column for tagEntities
+psql -U midas -d midas -c "ALTER TABLE ONLY midas_user ADD CONSTRAINT midas_user_username_key UNIQUE (username);"
+
+# Update the schema version
+psql -U midas -d midas -c "UPDATE schema SET version = 6 WHERE schema = 'current';"

--- a/tools/postgres/schema/current.sql
+++ b/tools/postgres/schema/current.sql
@@ -1190,6 +1190,14 @@ ALTER TABLE ONLY midas_user
 
 
 --
+-- Name: midas_user_username_key; Type: CONSTRAINT; Schema: public; Owner: midas; ablespace:
+--
+
+ALTER TABLE ONLY midas_user
+    ADD CONSTRAINT midas_user_username_key UNIQUE (username);
+
+
+--
 -- Name: notification_pkey; Type: CONSTRAINT; Schema: public; Owner: midas; Tablespace:
 --
 


### PR DESCRIPTION
This sets requires the `username` attribute of `user` models to be unique. If a new user model (account) is created with a `username` that matches an existing record in the database, and error will be passed on to the user:

> Unable to create new user. A record with that `username` already exists (`user's email address`)

This should put a hard stop to the issue that we keep seeing in #548. 

This PR also includes an additional catch to try to prevent the client from executing multiple account creation requests.

Requires running `npm run migrate` and should be merged after #656 

Finding and addressing the root cause would require a more thorough code review and likely refactor, as captured in https://github.com/18F/midas/issues/548#issuecomment-96748825