### PR TITLE
add agency and location to user export report

### DIFF
--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -343,7 +343,7 @@ module.exports = {
   },
 
   export: function (req, resp) {
-    User.find().exec(function (err, users) {
+    User.find().populate('tags').exec(function (err, users) {
       if (err) {
         sails.log.error("user query error. " + err);
         resp.send(400, {message: 'An error occurred while looking up users.', error: err});

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -56,14 +56,15 @@ module.exports = {
     }
   },
 
-  // TODO: add more fields, likely driven off subqueries
   exportFormat: {
     'user_id': 'id',
     'name': {field: 'name', filter: exportUtils.nullToEmptyString},
     'username': {field: 'username', filter: exportUtils.nullToEmptyString},
     'title': {field: 'title', filter: exportUtils.nullToEmptyString},
+    'agency': {field: 'agency', src: 'tags', filter: exportUtils.getAgency},
+    'location': {field: 'location', src: 'tags', filter: exportUtils.getLocation},
     'bio': {field: 'bio', filter: exportUtils.nullToEmptyString},
-    'isAdmin': 'isAdmin',
+    'admin': 'isAdmin',
     'disabled': 'disabled'
   }
 

--- a/api/services/utils/export.js
+++ b/api/services/utils/export.js
@@ -24,9 +24,11 @@ module.exports = {
 
     // clean up records
     fields.forEach(function (field, fIndex, fields) {
+      // if the "field" is a string, deref it, else use field.filter(field.field)
       if (typeof(field) === "object") {
         records.forEach(function (rec, rIndex, records) {
-          records[rIndex][field.field] = field.filter.call(this, rec[field.field]);
+          var sourceField = ('src' in field) ? field.src : field.field;
+          records[rIndex][field.field] = field.filter.call(this, rec[sourceField]);
         });
         fields[fIndex] = field.field;
       }
@@ -59,6 +61,18 @@ module.exports = {
    */
   nullToEmptyString: function (str) {
     return str ? str : "";
-  }
+  },
 
+  /**
+   * Find and extract the right tag
+   */
+  getAgency: function(tags) {
+    var tag = _.findWhere(tags, { type: 'agency' });
+    return (tag) ? tag.name : "";
+  },
+
+  getLocation: function(tags) {
+    var tag = _.findWhere(tags, { type: 'location' });
+    return (tag) ? tag.name : "";
+  }
 };

--- a/test/api/sails/admin.test.js
+++ b/test/api/sails/admin.test.js
@@ -139,7 +139,7 @@ describe('admin:', function () {
           var adminEmail = obj.emails[0];
           request.put({
             url: conf.url + '/useremail/' + emailBefore.id,
-            form: { email: emailAfter },
+            form: { email: emailAfter }
           }, function(err, response, body) {
             if (err) { return done(err); }
             // Logged in users should get a 200 with the user object
@@ -158,10 +158,10 @@ describe('admin:', function () {
         url: conf.url + '/user/export'
       }, function (err, response, body) {
         assert.equal(response.statusCode, 200);
-        var testBody = '"user_id","name","username","title","bio","isAdmin","disabled"\n' +
-            '1,"","tester1@midascrowd.com","","",false,false\n' +
-            '2,"","admin@midascrowd.com","","",true,false\n' +
-            '3,"","testreset@midascrowd.com","","",false,false\n'
+        var testBody = '"user_id","name","username","title","agency","location","bio","admin","disabled"\n' +
+            '1,"","tester1@midascrowd.com","","","","",false,false\n' +
+            '2,"","admin@midascrowd.com","","","","",true,false\n' +
+            '3,"","testreset@midascrowd.com","","","","",false,false\n';
         assert.equal(body, testBody);
         done(err);
       });

--- a/test/api/sails/helpers/config.js
+++ b/test/api/sails/helpers/config.js
@@ -57,6 +57,10 @@ module.exports = {
     {
       'type': 'office',
       'name': 'Tag3'
+    },
+    {
+      'type': 'location',
+      'name': 'San Francisco'
     }
   ]
 };


### PR DESCRIPTION
Add two columns derived from tags, relying on @dhcole's tag ORM refactor to do the heavy lifting. Fixes issue #717.

Note that while I was in here I changed the column name from "isAdmin" to just "admin," both to make it more clear, and to be consistent with the next column, "disabled." This might not be the kind of change that we'd want to do later, but I'm guessing that people aren't using this report much yet and it's early enough to make a change like that.