### PR TITLE
Enable CSRF tokens. Resolves #728

### DIFF
--- a/assets/js/backbone/app.js
+++ b/assets/js/backbone/app.js
@@ -4,6 +4,17 @@
  * running.
  */
 
+// Set CSRF header
+$.ajaxPrefilter(function(options, originalOptions, jqXHR) {
+  var token;
+  if (!options.crossDomain) {
+    token = $('meta[name="csrf-token"]').attr('content');
+    if (token) {
+      return jqXHR.setRequestHeader('X-CSRF-Token', token);
+    }
+  }
+});
+
 // Install jQuery plugins
 require('blueimp-file-upload/js/vendor/jquery.ui.widget');
 i18n = require('i18next-client/i18next.commonjs.withJQuery');

--- a/config/csrf.js
+++ b/config/csrf.js
@@ -39,4 +39,4 @@ console.log('Loading... ', __filename);
  * http://en.wikipedia.org/wiki/Cross-site_request_forgery
  */
 
-module.exports.csrf = false;
+module.exports.csrf = true;

--- a/test/test.upstart.js
+++ b/test/test.upstart.js
@@ -20,7 +20,8 @@ before(function(done) {
     hooks: {
       grunt: false,
       sockets: false,
-      pubsub: false
+      pubsub: false,
+      csrf: false
     }
   }
 

--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="csrf-token" content="<%= _csrf %>">
     <!-- Viewport mobile tag for sensible mobile support -->
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
 


### PR DESCRIPTION
CSRF tokens prevent a certain type of session attack. This turns on verification of a valid CSRF token for all non-`get` requests to the API, provides the token as an HTML `meta` tag, and adds the token as an HTTP header to all `$.ajax` requests.

More: http://sailsjs.org/#!/documentation/concepts/Security/CSRF.html