### PR TITLE
Add populate method to Task controller findByProjectId method

### DIFF
--- a/api/controllers/TaskController.js
+++ b/api/controllers/TaskController.js
@@ -50,6 +50,7 @@ module.exports = {
 
   findAllByProjectId: function (req, res) {
     Task.findByProjectId(req.params.id)
+    .populate('tags')
     .sort({'updatedAt': -1})
     .exec(function(err, tasks) {
       if (err) return res.send(err, 500);


### PR DESCRIPTION
Added populate method so tags appear again in Project listing of associated tasks.

Fixes #750 
