### PR TITLE
Issue 715: Button positioning bug while adding project owners

### DIFF
--- a/assets/js/backbone/apps/projectowner/show/templates/projectowner_show_template.html
+++ b/assets/js/backbone/apps/projectowner/show/templates/projectowner_show_template.html
@@ -1,17 +1,17 @@
 <div class="box-pad-lr border-bottom">
   <h2><span data-i18n="ProjectOwnerPlural">Project Owners</span>
     <button id="owner-edit" name="owner-edit" class="btn btn-c0 btn-sm file-add owner-form-toggle">Add Owners</button>
-    <button id="owner-cancel" name="owner-cancel" class="btn btn-c0 btn-sm file-add owner-form-toggle">Cancel</button>
-    <button id="owner-save" name="owner-save" class="btn btn-c2 btn-sm file-add owner-form-toggle">Submit</button>
   </h2>
 </div>
 
-<div id="project-owners-form" class="box-pad-lr box-pad-t owner-form-toggle">
+<div id="project-owners-form" class="box-pad-lr box-pad-t owner-form-toggle clearfix">
   <form class="" role="form">
     <div class="form-group">
       <input style="width: 100%" id="owners" name="owners" type="hidden" value="Add Owner"/>
     </div>
   </form>
+  <button id="owner-save" name="owner-save" class="btn btn-c2 btn-sm projectowner-add owner-form-toggle">Submit</button>
+  <button id="owner-cancel" name="owner-cancel" class="btn btn-c0 btn-sm projectowner-add owner-form-toggle">Cancel</button>
 </div>
 
 <div id="project-owners-show" class="box-pad-lr box-pad-t owner-form-toggle">

--- a/assets/styles/application.css
+++ b/assets/styles/application.css
@@ -746,6 +746,13 @@ a.delete-projectowner, a.delete-volunteer {
   font-size: 7px;
 }
 
+.projectowner-add {
+  float: right;
+  margin-left: 5px;
+  margin-top: -3px;
+  text-transform: none;
+}
+
 a.delete-project-event {
   float:right;
   top: -2px;


### PR DESCRIPTION
**Problem:**
The 'Working Group Owners' section of the 'Edit Project' screen is too narrow to fit both the section header and the Cancel and Submit buttons, as documented in Issue #715.

**Solution:**
Move the buttons to be beneath the input field instead. Additionally, I switched the order of the buttons for visual consistency with the button ordering on the `Working Group Description` section.

The Working Group Owners section  should now look like the following screenshots in the editing state:
*Full width*
![Full width](http://i.imgur.com/8Vafj4y.png)
*Medium width*
![Medium width](http://i.imgur.com/Z4b20jN.png)
*Minimum width*
![Minimum width](http://i.imgur.com/O2bbyVm.png)
