### PR TITLE
Allow task creators to clone tasks

### DIFF
--- a/api/controllers/TaskController.js
+++ b/api/controllers/TaskController.js
@@ -58,6 +58,31 @@ module.exports = {
     });
   },
 
+  clone: function(req, res) {
+    Task.findOneById(req.body.taskId)
+    .populate('tags')
+    .exec(function(err, task) {
+      if (err) return res.send(err, 500);
+      // Create a new task, copying over the following from the original:
+      // projectId, title, description
+      // Don't copy over the task state or any dates
+      // TODO: Implement cloning tags as well
+      var data = {
+        title: req.body.title ? req.body.title : task.title,
+        description: task.description,
+        projectId: task.projectId
+      };
+
+      Task.create(data)
+      .exec(function(err, newTask) {
+        res.send({
+          title: newTask.title,
+          taskId: newTask.id
+        });
+      });
+    });
+  },
+
   export: function (req, resp) {
     Task.find().exec(function (err, tasks) {
       if (err) {

--- a/api/controllers/TaskController.js
+++ b/api/controllers/TaskController.js
@@ -58,24 +58,24 @@ module.exports = {
     });
   },
 
-  clone: function(req, res) {
+  copy: function(req, res) {
     Task.findOneById(req.body.taskId)
     .populate('tags')
     .exec(function(err, task) {
       if (err) return res.send(err, 500);
 
-      // Create a new task, copying over the following from the original:
+      // Create a new task draft, copying over the following from the original:
       // projectId, title, description, tags
-      // Don't copy over the task state
-      var taskCloneData = {
+      var taskCopyData = {
         title: req.body.title !== undefined ? req.body.title : task.title,
         description: task.description,
-        userId: req.user[0].id,
+        userId: req.body.userId,
         projectId: task.projectId,
+        state: 'draft',
         tags: task.tags
       };
 
-      Task.create(taskCloneData)
+      Task.create(taskCopyData)
       .exec(function(err, newTask) {
         if (err) return res.send(err, 500);
 

--- a/api/controllers/TaskController.js
+++ b/api/controllers/TaskController.js
@@ -70,7 +70,6 @@ module.exports = {
         title: req.body.title !== undefined ? req.body.title : task.title,
         description: task.description,
         userId: req.body.userId,
-        projectId: task.projectId,
         state: 'draft',
         tags: task.tags
       };

--- a/api/controllers/TaskController.js
+++ b/api/controllers/TaskController.js
@@ -63,22 +63,23 @@ module.exports = {
     .populate('tags')
     .exec(function(err, task) {
       if (err) return res.send(err, 500);
+
       // Create a new task, copying over the following from the original:
-      // projectId, title, description
-      // Don't copy over the task state or any dates
-      // TODO: Implement cloning tags as well
-      var data = {
-        title: req.body.title ? req.body.title : task.title,
+      // projectId, title, description, tags
+      // Don't copy over the task state
+      var taskCloneData = {
+        title: req.body.title !== undefined ? req.body.title : task.title,
         description: task.description,
-        projectId: task.projectId
+        userId: req.user[0].id,
+        projectId: task.projectId,
+        tags: task.tags
       };
 
-      Task.create(data)
+      Task.create(taskCloneData)
       .exec(function(err, newTask) {
-        res.send({
-          title: newTask.title,
-          taskId: newTask.id
-        });
+        if (err) return res.send(err, 500);
+
+        res.send({ taskId: newTask.id, title: newTask.title });
       });
     });
   },

--- a/assets/js/backbone/apps/tasks/show/controllers/task_show_controller.js
+++ b/assets/js/backbone/apps/tasks/show/controllers/task_show_controller.js
@@ -16,7 +16,7 @@ var VolunteerSupervisorNotifyTemplate = require('../templates/volunteer_supervis
 var VolunteerTextTemplate = require('../templates/volunteer_text_template.html');
 var ChangeStateTemplate = require('../templates/change_state_template.html');
 var UpdateNameTemplate = require('../templates/update_name_template.html');
-var CloneTaskTemplate = require('../templates/clone_task_template.html');
+var CopyTaskTemplate = require('../templates/copy_task_template.html');
 
 
 var popovers = new Popovers();
@@ -35,7 +35,7 @@ var TaskShowController = BaseView.extend({
     'click #volunteered'              : 'volunteered',
     "click #task-close"               : "stateChange",
     "click #task-reopen"              : "stateReopen",
-    "click #task-clone"               : "clone",
+    "click #task-copy"                : "copy",
     "click .link-backbone"            : linkBackbone,
     "click .delete-volunteer"         : 'removeVolunteer',
     "mouseenter .project-people-div"  : popovers.popoverPeopleOn,
@@ -95,6 +95,7 @@ var TaskShowController = BaseView.extend({
     this.$(".li-task-view").show();
     this.$(".li-task-edit").hide();
     this.$(".task-view").hide();
+    this.$(".li-task-copy").hide();
   },
 
   initializeChildren: function () {
@@ -482,44 +483,44 @@ var TaskShowController = BaseView.extend({
     this.model.trigger("task:update:state", 'open');
   },
 
-  clone: function (e) {
+  copy: function (e) {
     if (e.preventDefault) e.preventDefault();
     var self = this;
 
     if (this.modalAlert) { this.modalAlert.cleanup(); }
     if (this.modalComponent) { this.modalComponent.cleanup(); }
 
-    var modalContent = _.template(CloneTaskTemplate)();
+    var modalContent = _.template(CopyTaskTemplate)();
 
     this.modalComponent = new ModalComponent({
-      el: "#modal-clone",
-      id: "check-clone",
-      modalTitle: "Clone This Opportunity"
+      el: "#modal-copy",
+      id: "check-copy",
+      modalTitle: "Copy This Opportunity"
     }).render();
 
     this.modalAlert = new ModalAlert({
-      el: "#check-clone .modal-template",
-      modalDiv: '#check-clone',
+      el: "#check-copy .modal-template",
+      modalDiv: '#check-copy',
       content: modalContent,
       validateBeforeSubmit: true,
       cancel: 'Cancel',
-      submit: 'Clone Opportunity',
+      submit: 'Copy Opportunity',
       callback: function (e) {
         $.ajax({
-          url: '/api/task/clone',
+          url: '/api/task/copy',
           method: 'POST',
           data: {
             taskId: self.model.attributes.id,
-            title: $('#task-clone-title').val()
+            title: $('#task-copy-title').val()
           }
         }).done(function(data) {
-          self.options.router.navigate('/tasks/' + data.taskId,
+          self.options.router.navigate('/tasks/' + data.taskId + '/edit',
                                        { trigger: true });
         });
       }
     }).render();
 
-    $('#task-clone-title').val(self.model.attributes.title + ' Clone');
+    $('#task-copy-title').val('COPY ' + self.model.attributes.title);
   },
 
   cleanup: function () {

--- a/assets/js/backbone/apps/tasks/show/templates/clone_task_template.html
+++ b/assets/js/backbone/apps/tasks/show/templates/clone_task_template.html
@@ -1,0 +1,8 @@
+<div class="title-clone">
+  <p>What would you like to title the clone of this <span data-i18n="task">opportunity</span>?</p>
+  <div class="form-group">
+    <input type="text" id="task-clone-title" class="fullwidth validate form-control" data-validate="empty,count100" name="task-clone-field" placeholder="Opportunity Description"/>
+    <span class="help-block error-empty" style="display:none;">You must enter a title for this <span data-i18n="task">opportunity</span></span>
+    <span class="help-block error-count100" style="display:none;">The short description of the problem must be less than 100 characters.</span>
+  </div>
+</div>

--- a/assets/js/backbone/apps/tasks/show/templates/copy_task_template.html
+++ b/assets/js/backbone/apps/tasks/show/templates/copy_task_template.html
@@ -1,7 +1,7 @@
-<div class="title-clone">
-  <p>What would you like to title the clone of this <span data-i18n="task">opportunity</span>?</p>
+<div class="title-copy">
+  <p>What would you like to title the copy of this <span data-i18n="task">opportunity</span>?</p>
   <div class="form-group">
-    <input type="text" id="task-clone-title" class="fullwidth validate form-control" data-validate="empty,count100" name="task-clone-field" placeholder="Opportunity Description"/>
+    <input type="text" id="task-copy-title" class="fullwidth validate form-control" data-validate="empty,count100" name="task-copy-field" placeholder="Opportunity Description"/>
     <span class="help-block error-empty" style="display:none;">You must enter a title for this <span data-i18n="task">opportunity</span></span>
     <span class="help-block error-count100" style="display:none;">The short description of the problem must be less than 100 characters.</span>
   </div>

--- a/assets/js/backbone/apps/tasks/show/templates/task_show_item_template.html
+++ b/assets/js/backbone/apps/tasks/show/templates/task_show_item_template.html
@@ -55,22 +55,24 @@
             <span class="like-plural" id="like-text" data-plural="likes" data-singular="like">likes</span>
           </div>
           <div class="navbar-side border-bottom">
+            <div id="modal-copy"></div>
             <ul class="nav nav-pills nav-stacked">
               <li>
                 <a href="#" id="email"><i class="fa fa-envelope-o"></i> <span class="box-icon-text">Share</span></a>
               </li>
+              <% if (user) { %>
+              <li class="li-task-copy">
+                <a href="#" id="task-copy"><i class="fa fa-files-o"></i><span class="box-icon-text">Copy Opportunity</span></a>
+              </li>
+              <% } %>
             </ul>
           </div>
           <% if (model.isOwner || (user && user.isAdmin)) { %>
           <div class="navbar-side <% if (user) { %>border-bottom<% } %>">
             <div id="modal-close"></div>
-            <div id="modal-clone"></div>
             <ul class="nav nav-pills nav-stacked">
               <li class="li-task-edit">
                 <a href="#" id="task-edit"><i class="fa fa-pencil"></i> <span class="box-icon-text">Edit <span data-i18n="Task">Opportunity</span></span></a>
-              </li>
-              <li id="li-task-clone">
-                <a href="#" id="task-clone"><i class="fa fa-files-o"></i><span class="box-icon-text">Clone Opportunity</span></a>
               </li>
               <li class="li-task-view" style="display: none;">
                 <a href="#" id="task-view"><i class="fa fa-pencil"></i> <span class="box-icon-text">View <span data-i18n="Task">Opportunity</span></span></a>

--- a/assets/js/backbone/apps/tasks/show/templates/task_show_item_template.html
+++ b/assets/js/backbone/apps/tasks/show/templates/task_show_item_template.html
@@ -64,9 +64,13 @@
           <% if (model.isOwner || (user && user.isAdmin)) { %>
           <div class="navbar-side <% if (user) { %>border-bottom<% } %>">
             <div id="modal-close"></div>
+            <div id="modal-clone"></div>
             <ul class="nav nav-pills nav-stacked">
               <li class="li-task-edit">
                 <a href="#" id="task-edit"><i class="fa fa-pencil"></i> <span class="box-icon-text">Edit <span data-i18n="Task">Opportunity</span></span></a>
+              </li>
+              <li id="li-task-clone">
+                <a href="#" id="task-clone"><i class="fa fa-files-o"></i><span class="box-icon-text">Clone Opportunity</span></a>
               </li>
               <li class="li-task-view" style="display: none;">
                 <a href="#" id="task-view"><i class="fa fa-pencil"></i> <span class="box-icon-text">View <span data-i18n="Task">Opportunity</span></span></a>

--- a/config/policies.js
+++ b/config/policies.js
@@ -153,6 +153,7 @@ module.exports.policies = {
     'find': ['authenticated', 'task'],
     'findOne': ['authenticated', 'task'],
     'findAllByProjectId': ['authenticated', 'requireId', 'project'],
+    'copy': ['authenticated', 'requireUserId', 'addUserId'],
     'create': ['authenticated', 'requireUserId', 'addUserId'],
     'update': ['authenticated', 'requireUserId', 'requireId', 'projectId', 'task', 'ownerOrAdmin'],
     'destroy': ['authenticated', 'requireUserId', 'requireId', 'task', 'ownerOrAdmin'],

--- a/test/api/sails/task.test.js
+++ b/test/api/sails/task.test.js
@@ -76,6 +76,18 @@ describe('tasks:', function () {
         done(err);
       });
     });
+
+    it('clone', function (done) {
+      request.post({
+        url: conf.url + '/task/clone',
+        body: JSON.stringify({taskId: 1})
+      }, function (err, response, body) {
+        body = JSON.parse(body);
+        assert.equal(body.taskId, 3);
+        assert.equal(body.title, conf.tasks[0].title);
+        done(err);
+      });
+    });
   });
 
 });

--- a/test/api/sails/task.test.js
+++ b/test/api/sails/task.test.js
@@ -77,9 +77,9 @@ describe('tasks:', function () {
       });
     });
 
-    it('clone', function (done) {
+    it('copy', function (done) {
       request.post({
-        url: conf.url + '/task/clone',
+        url: conf.url + '/task/copy',
         body: JSON.stringify({taskId: 1})
       }, function (err, response, body) {
         body = JSON.parse(body);


### PR DESCRIPTION
**Change Summary**

*Server side changes:* This PR adds an endpoint to `TaskController`, `clone`. The endpoint accepts a task `id` and an optional `title` parameter (if no title is provided, the original title is used). It creates a new task instance, copying over the `projectId`, `title`, `description`, and `tags` from the original task. It then returns the id and title of the new task.

*Client side changes:* When viewing and editing a task, owners/admins now see an additional option:
![2015-05-03_2305](https://cloud.githubusercontent.com/assets/3292371/7449361/7e091628-f1e9-11e4-8cba-59d20e1d7688.png)
Selection the option opens a confirmation modal that prompts for the title for the new task (defaulted to the original title with 'Clone' appended to the end). When the clone is submitted and succeeds, the user is navigated to the new task.

---

I'd like some feedback about the UI for task cloning - I'm not sure just sending the user to the new task is the right thing to do. Other ideas:
* Keep the modal open until the clone finishes, and ask the user if they'd like to navigate to the clone or stay on the current task.
* Show an alert stating that the clone has been made and that they can view it at any time in their 'Opportunities Created' list.