### PR TITLE
If user is logged in and logs in with another account, log out first acc...

### DIFF
--- a/api/controllers/AuthController.js
+++ b/api/controllers/AuthController.js
@@ -13,6 +13,7 @@ var userUtils = require('../services/utils/user');
  * remote server.
  */
 function authenticate (req, res, strategy, json) {
+  if (req.user && json) req.logout();
   if (req.user) {
     passport.authorize(strategy, function (err, user, info)
     {

--- a/api/services/utils/user.js
+++ b/api/services/utils/user.js
@@ -672,7 +672,7 @@ module.exports = {
           User.findOneById(userAuth.userId, function (err, user) {
             if (!user || err) { return done(null, false, { message: 'Error looking up user.' }); }
             sails.log.debug('User Found:', user);
-            if (providerUser.id !== user.id) {
+            if (req.user && req.user[0] && req.user[0].id !== user.id) {
               return done(null, false, {
                 message: 'We\'re sorry, you can\'t connect that ' +
                   sails.config.auth.config.config[userAuth.provider].name +


### PR DESCRIPTION
...ount before trying to log into the second. Fix duplicate oauth match ID.

Fixes a bug in https://github.com/18F/midas/pull/729 that prevented signing in with oauth accounts.
Addresses issue in #747 that occurs when logging into a new account while currently logged in.