### PR TITLE
Location data fix

### DIFF
--- a/assets/js/backbone/apps/browse/controllers/browse_list_controller.js
+++ b/assets/js/backbone/apps/browse/controllers/browse_list_controller.js
@@ -166,7 +166,8 @@ Browse.ListController = BaseController.extend({
       return _(tags).map(function(tag) {
         return (tag.id && tag.id !== tag.name) ? +tag.id : {
           name: tag.name,
-          type: tag.tagType
+          type: tag.tagType,
+          data: tag.data
         };
       });
     }

--- a/assets/js/backbone/apps/profiles/show/views/profile_show_view.js
+++ b/assets/js/backbone/apps/profiles/show/views/profile_show_view.js
@@ -468,7 +468,8 @@ var ProfileShowView = Backbone.View.extend({
           .map(function(tag) {
             return (tag.id && tag.id !== tag.name) ? +tag.id : {
               name: tag.name,
-              type: tag.tagType
+              type: tag.tagType,
+              data: tag.data
             };
           }).unique().value();
 

--- a/assets/js/backbone/apps/project/show/views/project_item_coremeta_view.js
+++ b/assets/js/backbone/apps/project/show/views/project_item_coremeta_view.js
@@ -134,7 +134,8 @@ var ProjectItemCoreMetaView = Backbone.View.extend({
         }).map(function(tag) {
           return (tag.id && tag.id !== tag.name) ? +tag.id : {
             name: tag.name,
-            type: tag.tagType
+            type: tag.tagType,
+            data: tag.data
           };
         }).unique().value();
     }

--- a/assets/js/backbone/apps/tasks/edit/views/task_edit_form_view.js
+++ b/assets/js/backbone/apps/tasks/edit/views/task_edit_form_view.js
@@ -230,7 +230,8 @@ var TaskEditFormView = Backbone.View.extend({
               if (!tag) return;
               return (tag.id && tag.id !== tag.name) ? +tag.id : {
                 name: tag.name,
-                type: tag.tagType
+                type: tag.tagType,
+                data: tag.data
               };
             })
             .compact()

--- a/test/api/sails/tag.test.js
+++ b/test/api/sails/tag.test.js
@@ -110,6 +110,36 @@ describe('tag:', function() {
       });
     });
 
+    it('location tag', function (done) {
+      request.get({
+        url: conf.url + '/location/suggest?q=Camden,%20NJ'
+      }, function(err, response, body) {
+        assert.equal(response.statusCode, 200);
+        var b = JSON.parse(body);
+        assert.isAbove(body.length, 0);
+        var tag = {
+              name: body[0].name,
+              type: 'location',
+              data: _.omit(body[0], 'name')
+            };
+
+        request.post({ url: conf.url + '/tagentity',
+                       body: JSON.stringify(tag)
+                     }, function (err, response, body) {
+          if (err) { return done(err); }
+          assert.equal(response.statusCode, 200);
+          var b = JSON.parse(body);
+          // check that the values passed in are the same as those passed back
+          assert.equal(tag.name, b.name);
+          assert.equal(tag.type, b.type);
+          assert.deepEqual(tag.data, b.data);
+          done();
+        });
+
+      });
+    });
+
+
   });
 
   describe('logged out:', function () {

--- a/tools/postgres/addLocationData.js
+++ b/tools/postgres/addLocationData.js
@@ -23,7 +23,10 @@ Sails.lift({}, function(err, sails) {
       json: true
     }, function(err, res, body) {
       if (err) return cb(err);
-      if (!body[0]) return cb();
+      if (!body[0]) {
+        console.log('No location data found for ' + tag.name);
+        return cb();
+      }
       var data = _.omit(body[0], 'name');
       TagEntity.update(tag.id, { data: data }).exec(function(err) {
         if (err) return cb(err);

--- a/tools/postgres/addLocationData.js
+++ b/tools/postgres/addLocationData.js
@@ -1,0 +1,35 @@
+var Sails = require('sails'),
+    async = require('async'),
+    request = require('request');
+
+Sails.lift({}, function(err, sails) {
+  if (err) return console.error(err);
+
+  TagEntity.find({}).exec(function(err, files) {
+    if (err) return console.error(err);
+    async.each(files, addData, function(err) {
+      if (err) console.error(err);
+      console.log('Shutting down server');
+      Sails.lower();
+    });
+  });
+
+  function addData(tag, cb) {
+    if (tag.data || tag.type !== 'location') return cb();
+    request({
+      url: sails.config.httpProtocol + '://' +
+        sails.config.hostName +  '/api/location/suggest?q=' +
+        encodeURIComponent(tag.name),
+      json: true
+    }, function(err, res, body) {
+      if (err) return cb(err);
+      if (!body[0]) return cb();
+      var data = _.omit(body[0], 'name');
+      TagEntity.update(tag.id, { data: data }).exec(function(err) {
+        if (err) return cb(err);
+        console.log('Added location data for ' + tag.name);
+        cb();
+      });
+    });
+  }
+});


### PR DESCRIPTION
Fixes  #768

- adds missing `tag.data` property when saving new tags to profiles, tasks, and projects
- adds a test for the tag creation API that verifies location suggestions and saving location data
- adds a script to update locations missing data.

If you have locations without location data, you can bulk update them by running `node tools/postgres/addLocationData.js` from the project root directory.

cc @sefk 