### PR TITLE
Project opportunity listing overflow fix

### DIFF
--- a/assets/styles/application.css
+++ b/assets/styles/application.css
@@ -1282,6 +1282,10 @@ a.delete-comment {
 /*****************
 =  TASK LIST
 ******************/
+.task-scroll .task {
+  overflow-y: hidden;
+}
+
 .task-box {
   width: 240px;
   height: 307px;


### PR DESCRIPTION
Addresses #736 
Changes this behavior:
![screen shot 2015-05-08 at 10 37 02 am](https://cloud.githubusercontent.com/assets/7915386/7538505/694a1f2e-f56e-11e4-8cd6-30babc78fffd.png)

To this:
![screen shot 2015-05-08 at 10 37 35 am](https://cloud.githubusercontent.com/assets/7915386/7538509/7148b85c-f56e-11e4-9dec-e92b715a4811.png)


