### PR TITLE
Filter Required/Not Required from task list tag clouds

### DIFF
--- a/assets/js/backbone/apps/tasks/list/views/task_collection_view.js
+++ b/assets/js/backbone/apps/tasks/list/views/task_collection_view.js
@@ -29,6 +29,10 @@ var TaskListTemplate = require('../templates/task_collection_view_template.html'
 
 		render: function () {
 			_.each(this.tasksJson.tasks, function(task) {
+				// Filter out "Required"/"Not Required" from the task tag cloud
+				task.tags = _.filter(task.tags, function(tag) {
+					return tag.type !== "task-skills-required";
+				});
 				task.description = marked(task.description);
 			});
 			this.compiledTemplate = _.template(TaskListTemplate)(this.tasksJson);


### PR DESCRIPTION
**Problem:** In the list of tasks shown on a project page, the `task-skills-required` tag was being rendered into the tag cloud. This tag is used to denote whether skills for a task are required or not, but isn't helpful to show in the task tag clound.

**Solution:** Filter out tags of the `task-skills-required` type before rendering the tag cloud.

This PR should take a task listing like this:

![2015-05-11_1955](https://cloud.githubusercontent.com/assets/3292371/7579365/ba3a0268-f817-11e4-83f3-a4cb2fc04a1c.png)

and turn it into this:

![2015-05-11_1953](https://cloud.githubusercontent.com/assets/3292371/7579368/c54bd992-f817-11e4-87f3-76071936cef9.png)

