### PR TITLE
Fix config/env/dev migrate setting

### DIFF
--- a/config/env/development.js
+++ b/config/env/development.js
@@ -6,7 +6,5 @@ console.log('Loading... ', __filename);
 //         ( it undeletes things that have been soft deleted on sails lift )
 
 module.exports.models = {
-  migrate: 'alter',
-  'adapter': 'disk'
-
-}
+  migrate: 'safe'
+};


### PR DESCRIPTION
Reverses an accidentally committed change to the `config/eng/dev` model migration setting.

Should fix #785

cc @sefk 