### PR TITLE
Remove unsubscribe link from html email footer

### DIFF
--- a/assets/email/layouts/default/html.ejs
+++ b/assets/email/layouts/default/html.ejs
@@ -25,9 +25,6 @@
         <p>
         You received this email because you signed up for <a href="<%= globals.urlPrefix %>"><%= globals.systemName %></a>.
         </p>
-        <p>
-        You can unsubscribe from these emails or change your preferences by <a href="<%= globals.urlPrefix %>/profile/settings">managing your notifications</a>.
-        </p>
       </td>
     </tr>
   </table>


### PR DESCRIPTION
Removes unsubscribe link from the HTML footer, because it points to a not yet implemented part of the user profile.