### PR TITLE
Fixes non breaking long strings in Project Description

### DIFF
--- a/assets/styles/application.css
+++ b/assets/styles/application.css
@@ -742,6 +742,7 @@ a.search-tag-remove:hover {
   font-size: 16px;
   margin-bottom: 20px;
   line-height: 1.5em;
+  word-wrap: break-word;
 }
 
 .project-status {


### PR DESCRIPTION
Currently, a long word/url can cause this behavior:
![screen shot 2015-05-18 at 11 01 00 am](https://cloud.githubusercontent.com/assets/7915386/7683461/61aa3344-fd4d-11e4-8d7f-6041c98236ee.png)

This change causes the same content to be rendered like this:
![screen shot 2015-05-18 at 11 00 15 am](https://cloud.githubusercontent.com/assets/7915386/7683466/6e5ee602-fd4d-11e4-8b0c-53a366556aee.png)

This is a low-risk change as this class is only used in one place.
