### PR TITLE
Fix html new term suggestion in search w/escape

### DIFF
--- a/assets/js/backbone/apps/browse/views/browse_main_view.js
+++ b/assets/js/backbone/apps/browse/views/browse_main_view.js
@@ -45,6 +45,7 @@ var BrowseMainView = Backbone.View.extend({
   },
 
   format: function (self, object, container, query) {
+    var formatIcon = "";
     var name = object.name || object.title;
     var icon = this.tagIcon[object.type];
     if (object.target == 'project') {
@@ -52,12 +53,14 @@ var BrowseMainView = Backbone.View.extend({
     } else if (object.target == 'task') {
       icon = 'fa fa-tag';
     }
-    if (object.unmatched) {
-      //name is escaped in create search choice
-      return name;
-    } else {
-      return '<i class="' + _.escape(icon) + '"></i> <span class="box-icon-text">' + name + '</span>';
+
+    if ( !object.unmatched ) {
+      //unmatched name is escaped in createSearchChoice func to preserve html formatting
+      name = _.escape(name);
+      formatIcon = '<i class="' + _.escape(icon) + '"></i>';
     }
+
+    return  formatIcon+'<span class="box-icon-text">' + name + '</span>';
   },
 
   initializeSearch: function() {

--- a/assets/js/backbone/apps/browse/views/browse_main_view.js
+++ b/assets/js/backbone/apps/browse/views/browse_main_view.js
@@ -52,7 +52,12 @@ var BrowseMainView = Backbone.View.extend({
     } else if (object.target == 'task') {
       icon = 'fa fa-tag';
     }
-    return '<i class="' + _.escape(icon) + '"></i> <span class="box-icon-text">' + _.escape(name) + '</span>';
+    if (object.unmatched) {
+      //name is escaped in create search choice
+      return name;
+    } else {
+      return '<i class="' + _.escape(icon) + '"></i> <span class="box-icon-text">' + name + '</span>';
+    }
   },
 
   initializeSearch: function() {
@@ -93,7 +98,7 @@ var BrowseMainView = Backbone.View.extend({
           return object.name || object.title;
       },
       createSearchChoice: function (term) {
-          return { unmatched: true,id: term, value: term, name: "<b>"+term+"</b> <i>click to text search for this value.</i>" };
+          return { unmatched: true,id: term, value: term, name: "<b>"+_.escape(term)+"</b> <i>click to text search for this value.</i>" };
       },
       ajax: {
         url: '/api/ac/search/' + self.options.target,


### PR DESCRIPTION
- adds escape to new (unmatched) search terms in the select2 drop down
- renders html correctly for new (unmatched) terms in the select2 drop down

This crept in when escapes were added.

Closes #799 

Thanks for the report @nhu313