### PR TITLE
Remove event modal after close. Fixes #803

### DIFF
--- a/assets/js/backbone/apps/events/list/controllers/event_list_controller.js
+++ b/assets/js/backbone/apps/events/list/controllers/event_list_controller.js
@@ -86,6 +86,11 @@ EventList = Backbone.View.extend({
       projectId: this.options.projectId,
       collection: this.collection
     }).render();
+
+    $('#addEvent').bind('hidden.bs.modal', function() {
+      $('#addEvent').remove();
+    }).modal('hide');
+
   },
 
   updatePeople: function (e, inc) {


### PR DESCRIPTION
The event modal wasn't being removed after closing, which caused the validation of other modals, such as for creating a new opportunity, to try to validate the empty event form.

This PR removes the modal on its hide event.