### PR TITLE
Faster dev builds with npm run watch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,26 @@ We also have a [wiki](https://github.com/18F/midas/wiki) where we keep various d
 
 This project follows the [git flow](http://nvie.com/posts/a-successful-git-branching-model/) branching model of product development.
 
+### Watch command
+
+Use `npm run watch` to automatically regenerate the application after changing files. This command will also source a `.env` file as a bash script if it exists. Use this for setting up environment variables for your development environment, such as:
+
+```sh
+# New Relic settings
+export NEW_RELIC_APP_NAME=midas-local-dev
+export NEW_RELIC_LICENSE_KEY=18956ab3a4d8c772
+
+# LinkedIn auth settings
+export LINKEDIN_CLIENT_ID=77xinrs
+export LINKEDIN_CLIENT_SECRET=11aw6wbHC
+export LINKEDIN_CALLBACK_URL=http://localhost:1337/api/auth/callback/linkedin
+
+# MyUSA auth settings
+export MYUSA_CLIENT_ID=0a33d1c4df848fa1ec666068285e903
+export MYUSA_CLIENT_SECRET=bc4b61e58a579efb8907f5d673cef9f34e
+export MYUSA_CALLBACK_URL=http://localhost:1337/api/auth/callback/myusa
+```
+
 ### Testing
 
 To run all the tests:

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -146,43 +146,25 @@ module.exports = function (grunt) {
       sample: {
         src:['assets/locales/**/*.json']
       }
-    },
-
-    watch: {
-      api: {
-
-        // API files to watch:
-        files: ['api/**/*']
-      },
-      assets: {
-
-        // Assets to watch:
-        files: ['assets/**/*'],
-
-        // When assets are changed:
-        tasks: [
-          'clean:prod',
-          // Check validity of JSON files.
-          'jsonlint',
-          // build js bundle
-          'browserify:dev',
-          // compile the css
-          'cssmin',
-          // copy fonts
-          'copy:font',
-          // copy css-support images (images that css expects to be in the css directory)
-          'copy:csssupport',
-          // copy assets
-          'copy:prod'
-        ]
-      }
     }
+
   });
 
   // When Sails is lifted:
   grunt.registerTask('default', [
-    'build',
-    'watch'
+    'clean:prod',
+    // Check validity of JSON files.
+    'jsonlint',
+    // build js bundle
+    'browserify:dev',
+    // compile the css
+    'cssmin',
+    // copy fonts
+    'copy:font',
+    // copy css-support images (images that css expects to be in the css directory)
+    'copy:csssupport',
+    // copy assets
+    'copy:prod'
   ]);
 
   grunt.registerTask('build', [

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "init": "mocha test/test.upstart.js --development --recursive test/init",
     "demo": "mocha test/test.upstart.js --development --recursive test/demo",
     "import": "cp -v $npm_package_config_dir/exclude.txt exclude.txt | true && rsync -av --exclude-from=exclude.txt $npm_package_config_dir/* .",
-    "watch": "source .env && nodemon --watch assets --watch api --watch config --watch views -i assets/build"
+    "watch": "source .env | true && nodemon --watch assets --watch api --watch config --watch views -i assets/build"
   },
   "main": "app.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "init": "mocha test/test.upstart.js --development --recursive test/init",
     "demo": "mocha test/test.upstart.js --development --recursive test/demo",
     "import": "cp -v $npm_package_config_dir/exclude.txt exclude.txt | true && rsync -av --exclude-from=exclude.txt $npm_package_config_dir/* .",
-    "watch": "source .env && nodemon -i assets/build"
+    "watch": "source .env && nodemon --watch assets --watch api --watch config --watch views -i assets/build"
   },
   "main": "app.js",
   "repository": {


### PR DESCRIPTION
Some improvements to the development workflow to speed things up. Now, during development, simply run `npm run watch` to start the application and have it restart on changes.

Removes the grunt-based watch task in favor of `npm run watch`, which uses nodemon. Modifies the default grunt task run on `sails lift` to only build the dev assets, which is faster because it avoids uglifying the files.

:ship: :dash: 