### PR TITLE
Redirect to referring url after oauth login

### DIFF
--- a/api/controllers/AuthController.js
+++ b/api/controllers/AuthController.js
@@ -75,7 +75,8 @@ function authenticate (req, res, strategy, json) {
           res.send(userUtils.cleanUser(user, user.id));
         }
         else {
-          res.redirect(sails.config.ui.home.logged_in_path);
+          res.redirect(req.session.logged_in_path || sails.config.ui.home.logged_in_path);
+          delete req.session.logged_in_path;
         }
         return;
       });
@@ -237,7 +238,12 @@ module.exports = {
     if (!target || target === '' || !_.contains(sails.config.auth.config.oauth, target)) {
       return res.send(403, { message: "Unsupported OAuth method." });
     }
-    var config = sails.config.auth.config.config;
+    var config = sails.config.auth.config.config,
+        path = req.headers.referer.split('://')[1].split(req.headers.host)[1];
+
+    // Set referer path for redirection after authentication
+    req.session.logged_in_path = path;
+
     passport.authenticate(target, config[target].params || null)(req, res, function (err) {
       if (err) {
         sails.log.error('Authentication Error:', err);

--- a/assets/js/backbone/apps/tasks/show/controllers/task_show_controller.js
+++ b/assets/js/backbone/apps/tasks/show/controllers/task_show_controller.js
@@ -317,7 +317,10 @@ var TaskShowController = BaseView.extend({
   volunteer: function (e) {
     if (e.preventDefault) e.preventDefault();
     if (!window.cache.currentUser) {
-      window.cache.taskVolunteer = this.model.id;
+      Backbone.history.navigate(window.location.pathname + '?volunteer', {
+        trigger: false,
+        replace: true
+      });
       window.cache.userEvents.trigger("user:request:login");
     } else {
       var self = this;

--- a/assets/js/backbone/apps/tasks/show/views/task_item_view.js
+++ b/assets/js/backbone/apps/tasks/show/views/task_item_view.js
@@ -44,9 +44,13 @@ var TaskItemView = BaseView.extend({
     $("time.timeago").timeago();
     self.updateTaskEmail();
     self.model.trigger('task:show:render:done');
-	if (window.cache.taskVolunteer && !self.model.attributes.volunteer) {
+    if (window.location.search === '?volunteer' &&
+        !self.model.attributes.volunteer) {
       $('#volunteer').click();
-      delete window.cache.taskVolunteer;
+      Backbone.history.navigate(window.location.pathname, {
+        trigger: false,
+        replace: true
+      });
     }
   },
 


### PR DESCRIPTION
This PR redirects the user to the referring url after logging in with an oauth account. This addresses the issue where logging into the `/people` page redirected away.

It also changes the way the volunteer modal is triggered after log-in so that it works with oauth accounts.

Closes #724 

