### PR TITLE
only allow modal textareas to be resized vertically

### DIFF
--- a/assets/styles/application.css
+++ b/assets/styles/application.css
@@ -214,6 +214,10 @@ input[type="submit"] {
   border-radius: 3px;
 }
 
+.modal-content textarea {
+  resize: vertical;
+}
+
 .modal-footer-text {
   font-size: 13px;
   text-align: left;


### PR DESCRIPTION
Fixes #844: Constrains modal textareas by only allowing them to be resized vertically.

Tested in Firefox 38, Chrome 43