### PR TITLE
handle NULL responses from findOne() query

### DIFF
--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -69,8 +69,8 @@ module.exports = {
     }
     sails.services.utils.user.getUser(userId, reqId, req.user, function (err, user) {
       // this will only be shown to logged in users.
-      if (userId !== reqId) user.username = null;
       if (err) { return res.send(400, err); }
+      if (userId !== reqId) user.username = null;
       sails.log.debug('User Get:', user);
       res.send(user);
     });

--- a/api/services/utils/task.js
+++ b/api/services/utils/task.js
@@ -15,6 +15,7 @@ var authorized = function (id, userId, user, cb) {
   }
   Task.findOneById(id).populate('tags').exec(function (err, task) {
     if (err) { return cb('Error finding task.', null); }
+    if (!task) { return cb('Task not found.', null); }
     task.isOwner = false;
     // otherwise, check that we have an owner
     if (userId && (userId == task.userId)) {

--- a/api/services/utils/task.js
+++ b/api/services/utils/task.js
@@ -14,8 +14,7 @@ var authorized = function (id, userId, user, cb) {
     user = undefined;
   }
   Task.findOneById(id).populate('tags').exec(function (err, task) {
-    if (err) { return cb('Error finding task.', null); }
-    if (!task) { return cb('Task not found.', null); }
+    if (err || !task) { return cb('Error finding task.', null); }
     task.isOwner = false;
     // otherwise, check that we have an owner
     if (userId && (userId == task.userId)) {

--- a/api/services/utils/user.js
+++ b/api/services/utils/user.js
@@ -756,8 +756,7 @@ module.exports = {
       reqUser = undefined;
     }
     User.findOne({ id: userId }).populate('tags').exec(function (err, user) {
-      if (err) { return cb(err, null); }
-      if (!user) { return cb("User not found", null); }
+      if (err || !user) { return cb("Error finding User.", null); }
       delete user.deletedAt;
       if (userId != reqId) {
         user = self.cleanUser(user, reqId);

--- a/api/services/utils/user.js
+++ b/api/services/utils/user.js
@@ -757,6 +757,7 @@ module.exports = {
     }
     User.findOne({ id: userId }).populate('tags').exec(function (err, user) {
       if (err) { return cb(err, null); }
+      if (!user) { return cb("User not found", null); }
       delete user.deletedAt;
       if (userId != reqId) {
         user = self.cleanUser(user, reqId);


### PR DESCRIPTION
Fixes #848,

This solution uses the existing error reporting code in the `UserController`, which sends a 400, and results in a blank page. I'm currently working on the 404 page issue (#149) to make the frontend a little more helpful when this happens.

*edit: also fixes the `/tasks/:id` route, which suffered from the same problem. The `/project/:id` route [already performs this check](https://github.com/18F/midas/blob/devel/api/services/utils/project.js#L12)*