### PR TITLE
added simple 404 responses

### DIFF
--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -69,7 +69,7 @@ module.exports = {
     }
     sails.services.utils.user.getUser(userId, reqId, req.user, function (err, user) {
       // this will only be shown to logged in users.
-      if (err) { return res.send(400, err); }
+      if (err) { return res.send(400, { message: err }); }
       if (userId !== reqId) user.username = null;
       sails.log.debug('User Get:', user);
       res.send(user);

--- a/api/policies/project.js
+++ b/api/policies/project.js
@@ -10,7 +10,7 @@ module.exports = function project (req, res, next) {
       userId = req.user[0].id;
     }
     util.authorized(req.route.params.id, userId, function (err, proj) {
-      if (err) { return res.send({ message: err }); }
+      if (err) { return res.send(404, { message: err }); }
       if (!err && !proj) { return res.send(403, { message: 'Not authorized.'}); }
       req.proj = proj;
       req.projectId = proj.id;

--- a/api/policies/project.js
+++ b/api/policies/project.js
@@ -10,7 +10,7 @@ module.exports = function project (req, res, next) {
       userId = req.user[0].id;
     }
     util.authorized(req.route.params.id, userId, function (err, proj) {
-      if (err) { return res.send(404, { message: err }); }
+      if (err) { return res.send(400, { message: err }); }
       if (!err && !proj) { return res.send(403, { message: 'Not authorized.'}); }
       req.proj = proj;
       req.projectId = proj.id;

--- a/api/policies/task.js
+++ b/api/policies/task.js
@@ -9,7 +9,7 @@ module.exports = function task (req, res, next) {
         userId = (user) ? user.id : null;
 
     util.authorized(req.route.params.id, userId, user, function (err, task) {
-      if (err) { return res.send({ message: err }); }
+      if (err) { return res.send(404, { message: err }); }
       if (!err && !task) { return res.send(403, { message: 'Not authorized.'}); }
       req.task = task;
       req.taskId = task.id;

--- a/api/policies/task.js
+++ b/api/policies/task.js
@@ -9,7 +9,7 @@ module.exports = function task (req, res, next) {
         userId = (user) ? user.id : null;
 
     util.authorized(req.route.params.id, userId, user, function (err, task) {
-      if (err) { return res.send(404, { message: err }); }
+      if (err) { return res.send(400, { message: err }); }
       if (!err && !task) { return res.send(403, { message: 'Not authorized.'}); }
       req.task = task;
       req.taskId = task.id;

--- a/assets/js/backbone/apps/browse/browse_app.js
+++ b/assets/js/backbone/apps/browse/browse_app.js
@@ -19,7 +19,7 @@ var PeopleController = require('../people/controllers/people_main_controller');
 var BrowseRouter = Backbone.Router.extend({
 
   routes: {
-    ''                   : 'showHome',
+    ''                          : 'showHome',
     'projects(/)'               : 'listProjects',
     'projects/:id(/)'           : 'showProject',
     'projects/:id/:action(/)'   : 'showProject',

--- a/assets/js/backbone/apps/project/show/controllers/project_show_controller.js
+++ b/assets/js/backbone/apps/project/show/controllers/project_show_controller.js
@@ -16,6 +16,7 @@ var ModalComponent = require('../../../../components/modal');
 var ModalAlert = require('../../../../components/modal_alert');
 var TaskModel = require('../../../../entities/tasks/task_model');
 var ProjectOpenTasksWarningTemplate = require('../templates/project_open_tasks_warning_template.html');
+var AlertTemplate = require('../../../../components/alert_template.html');
 
 
 var popovers = new Popovers();
@@ -75,6 +76,12 @@ Project.ShowController = BaseController.extend({
         }
       }
       self.initializeItemView();
+    });
+
+    this.listenTo(this.model, "project:model:fetch:error", function (projectModel, xhr) {
+      //this template is populated by the Global AJAX error listener
+      var template = _.template(AlertTemplate)();
+      this.$el.html(template);
     });
 
     this.model.on("project:show:rendered", function () {

--- a/assets/js/backbone/apps/project/show/controllers/project_show_controller.js
+++ b/assets/js/backbone/apps/project/show/controllers/project_show_controller.js
@@ -81,7 +81,7 @@ Project.ShowController = BaseController.extend({
     this.listenTo(this.model, "project:model:fetch:error", function (projectModel, xhr) {
       //this template is populated by the Global AJAX error listener
       var template = _.template(AlertTemplate)();
-      this.$el.html(template);
+      self.$el.html(template);
     });
 
     this.model.on("project:show:rendered", function () {

--- a/assets/js/backbone/apps/tasks/show/views/task_item_view.js
+++ b/assets/js/backbone/apps/tasks/show/views/task_item_view.js
@@ -8,6 +8,7 @@ var marked = require('marked');
 var TimeAgo = require('../../../../../vendor/jquery.timeago');
 var BaseView = require('../../../../base/base_view');
 var TaskShowTemplate = require('../templates/task_show_item_template.html');
+var AlertTemplate = require('../../../../components/alert_template.html');
 
 
 var TaskItemView = BaseView.extend({
@@ -20,6 +21,13 @@ var TaskItemView = BaseView.extend({
       self.model = model;
       self.initializeTags(self);
     });
+    this.listenTo(this.model, "task:model:fetch:error", function (projectModel, xhr) {
+      //this template is populated by the Global AJAX error listener
+      var template = _.template(AlertTemplate)();
+      self.$el.html(template);
+    });
+
+
   },
 
   render: function (self) {

--- a/assets/js/backbone/entities/projects/project_model.js
+++ b/assets/js/backbone/entities/projects/project_model.js
@@ -47,8 +47,11 @@ var ProjectModel = Backbone.Model.extend({
     var self = this;
     this.set({ id: id });
     this.fetch({
-      success: function (data) {
-        self.trigger("project:model:fetch:success", data);
+      success: function (model) {
+        self.trigger("project:model:fetch:success", model);
+      },
+      error: function (model, xhr) {
+        self.trigger("project:model:fetch:error", model, xhr);
       }
     });
   },

--- a/assets/js/backbone/entities/projects/project_model.js
+++ b/assets/js/backbone/entities/projects/project_model.js
@@ -47,11 +47,11 @@ var ProjectModel = Backbone.Model.extend({
     var self = this;
     this.set({ id: id });
     this.fetch({
-      success: function (model) {
-        self.trigger("project:model:fetch:success", model);
+      success: function (data) {
+        self.trigger("project:model:fetch:success", data);
       },
-      error: function (model, xhr) {
-        self.trigger("project:model:fetch:error", model, xhr);
+      error: function (data, xhr) {
+        self.trigger("project:model:fetch:error", data, xhr);
       }
     });
   },

--- a/assets/js/backbone/entities/tasks/task_model.js
+++ b/assets/js/backbone/entities/tasks/task_model.js
@@ -74,6 +74,9 @@ var TaskModel = Backbone.Model.extend({
     this.fetch({
       success: function (data) {
         self.trigger("task:model:fetch:success", data);
+      },
+      error: function(data, xhr) {
+        self.trigger("task:model:fetch:error", data, xhr);
       }
     });
   },


### PR DESCRIPTION
This is a first crack at #149 

When an item isn't found, instead of showing blank project/task/profile pages, this PR uses the `alert_template` to display the error the from the server.

**It turns this:**

![before-not-found](https://cloud.githubusercontent.com/assets/6355971/8219196/3ef41604-1516-11e5-86ad-7988a6c41f56.png)

**into this:**

![not-found-alert](https://cloud.githubusercontent.com/assets/6355971/8219200/476c9900-1516-11e5-8044-21dcaa4dea3e.png)