### PR TITLE
Removed image from groups that don't provide one.

### DIFF
--- a/assets/js/backbone/apps/browse/templates/project_list_item.html
+++ b/assets/js/backbone/apps/browse/templates/project_list_item.html
@@ -2,7 +2,7 @@
   <% if (item.coverId) { %>
   <div class="project-background-image border-bottom" style="background-image: url(/api/file/get/<%- item.coverId %>)">
   <% } else { %>
-  <div class="project-background-image border-bottom project-background-image-default">
+  <div>
   <% } %>
   </div>
   <div class="project-title">


### PR DESCRIPTION
Issue #759. Removed image from groups that don't have one uploaded. (Groups still show default image on their individual page.) 
![screen shot 2015-06-18 at 10 49 58 am](https://cloud.githubusercontent.com/assets/9591943/8234074/d7065da8-15a7-11e5-9f87-0dddf8a6ef3e.png)
