### PR TITLE
escape the comment author's name

### DIFF
--- a/assets/js/backbone/apps/comments/list/controllers/comment_list_controller.js
+++ b/assets/js/backbone/apps/comments/list/controllers/comment_list_controller.js
@@ -160,7 +160,7 @@ Comment = Backbone.View.extend({
         $('html,body').animate({scrollTop: inputTarget.offset().top},'slow');
       }
 
-      var replyto          = $(e.currentTarget).data("commentauthor");
+      var replyto = _.escape($(e.currentTarget).data("commentauthor"));
       var authorid         = $(e.currentTarget).data("authorid");
       var replyToCommentId = $(e.currentTarget).data("commentid");
       var quote            = $("#comment-id-"+replyToCommentId).html();


### PR DESCRIPTION
The templating engine is correctly escaping data [here](https://github.com/18F/midas/blob/devel/assets/js/backbone/apps/comments/list/templates/comment_item_template.html#L30), however, when strings (that contain HTML entities) are retrieved from attributes, [they become unescaped](http://stackoverflow.com/questions/11224362/getattributename-unescapes-html).