### PR TITLE
added filtering policy for user UPDATE requests

### DIFF
--- a/api/policies/protectAdmin.js
+++ b/api/policies/protectAdmin.js
@@ -1,7 +1,10 @@
 /**
-* Only Admins should be able to set the isAdmin property of the model.
+* Only Admins should be able to UPDATE the isAdmin property of the model.
+* All other references to isAdmin should be scrubbed.
 */
 module.exports = function protectAdmin (req, res, next) {
-	delete req.body.isAdmin;
-	next();
+  if ( !(req.user && req.user[0].isAdmin) ) {
+    delete req.body.isAdmin;
+  }
+  next();
 };

--- a/api/policies/protectAdmin.js
+++ b/api/policies/protectAdmin.js
@@ -1,0 +1,7 @@
+/**
+* Only Admins should be able to set the isAdmin property of the model.
+*/
+module.exports = function protectAdmin (req, res, next) {
+	delete req.body.isAdmin;
+	next();
+};

--- a/config/policies.js
+++ b/config/policies.js
@@ -44,7 +44,7 @@ module.exports.policies = {
     'profile': ['authenticated'],
     'photo': ['authenticated', 'requireId'],
     'info': ['authenticated', 'requireId'],
-    'update': ['authenticated', 'requireUserId', 'requireId'],
+    'update': ['authenticated', 'requireUserId', 'requireId', 'protectAdmin'],
     'username': ['authenticated'],
     'find': ['authenticated', 'requireUserId'],
     'all': ['authenticated', 'requireUserId'],


### PR DESCRIPTION
prevents people from arbitrarily turning themselves into admins via the API.