### PR TITLE
Prevent users from editting other users via the API

### DIFF
--- a/api/policies/user.js
+++ b/api/policies/user.js
@@ -3,8 +3,16 @@
 */
 
 module.exports = function user (req, res, next) {
-  if (req.route.params.id == req.user[0].id) {
+  if (req.user && req.user[0].isAdmin) {
+    //admins are allowed to do anything
     return next();
+  } else {
+    if (req.route.params.id == req.user[0].id) {
+      //allow the currently logged in user to access themselves
+      return next();
+    } else {
+      //dissallow a user due to ID mismatch
+      return res.send(403, { message: 'Not authorized'});
+    }
   }
-  return res.send(403, { message: 'Not Authorized.' });
 };

--- a/config/policies.js
+++ b/config/policies.js
@@ -44,7 +44,7 @@ module.exports.policies = {
     'profile': ['authenticated'],
     'photo': ['authenticated', 'requireId'],
     'info': ['authenticated', 'requireId'],
-    'update': ['authenticated', 'requireUserId', 'requireId', 'protectAdmin'],
+    'update': ['authenticated', 'requireUserId', 'requireId', 'user', 'protectAdmin'],
     'username': ['authenticated'],
     'find': ['authenticated', 'requireUserId'],
     'all': ['authenticated', 'requireUserId'],


### PR DESCRIPTION
prevents non-admin users from updating other user's information via the API.

I edited an existing policy to allow admins to perform UPDATEs to arbitrary users. The only other place where this policy was used is [`UserEmailController.findAllByUserId`](https://github.com/18F/midas/blob/devel/config/policies.js#L64) (handled [here](https://github.com/18F/midas/blob/devel/api/controllers/UserEmailController.js#L10-L16)), which I *believe?* is also an acceptable admin action.