### PR TITLE
Fixed HTML comments in admin panel with marked

### DIFF
--- a/assets/js/backbone/apps/admin/views/admin_dashboard_view.js
+++ b/assets/js/backbone/apps/admin/views/admin_dashboard_view.js
@@ -6,6 +6,7 @@ var AdminDashboardTemplate = require('../templates/admin_dashboard_template.html
 var AdminDashboardTable = require('../templates/admin_dashboard_table.html');
 var AdminDashboardActivities = require('../templates/admin_dashboard_activities.html');
 var LoginConfig = require('../../../config/login.json');
+var marked = require('marked');
 
 
 var AdminDashboardView = Backbone.View.extend({
@@ -54,15 +55,22 @@ var AdminDashboardView = Backbone.View.extend({
     _(data).forEach(function(activity) {
 
       if (!activity || ( activity.comment && typeof activity.comment.value == "undefined") ) return;
-      // Strip HTML from comments
+      // Render markdown
       if (activity.comment) {
-        var value = activity.comment.value.replace(/<(?:.|\n)*?>/gm, '');
+        var value = activity.comment.value;
+
+        value = marked(value, { sanitize: false });
+        //render comment in single line by stripping the markdown-generated paragraphs
+        value = value.replace(/<\/?p>/gm, '');
+        value = value.replace(/<br>/gm, '');
+        value = value.trim();
+
         activity.comment.value = value;
       }
       // Format timestamp
       activity.createdAtFormatted = $.timeago(activity.createdAt);
       var template = self.$('#' + activity.type).text(),
-          content = _.template(template, { escape: /\{\{(.+?)\}\}/g })(activity);
+          content = _.template(template, { interpolate: /\{\{(.+?)\}\}/g })(activity);
       self.$('.activity-block .activity-feed').append(content);
     });
 


### PR DESCRIPTION
Fixes #865 

~~This PR no longer stores comments in the database in escaped form. [This `html()` call](https://github.com/18F/midas/blob/devel/assets/js/backbone/apps/comments/new/views/comment_form_view.js#L133) was returning entities, whereas the `text()` call below was returning raw content.~~ This PR also adds `marked` comment rendering to the admin panel, and uses it to escape the contents, rather than the escaping in `_.template()`. ~~This appears to be backwards compatible with a database full of escaped comments.~~