### PR TITLE
Fix navbar divider for mobile

### DIFF
--- a/assets/js/backbone/apps/nav/templates/nav_template.html
+++ b/assets/js/backbone/apps/nav/templates/nav_template.html
@@ -30,7 +30,7 @@
           </a>
         </li>
 
-        <li class="divider-vertical navbar-text"></li>
+        <li class="navbar-divider navbar-text"></li>
         <% if (user) { %>
           <li class="profile dropdown">
             <a href="/profile" id="navbar-profile" role="button" class="dropdown-toggle" data-toggle="dropdown">

--- a/assets/styles/application.css
+++ b/assets/styles/application.css
@@ -305,10 +305,19 @@ h1, h2, h3, h4, h5, h6 {
   font-size: 18px;
 }
 
-.navbar .nav .divider-vertical {
+.navbar .nav .navbar-divider {
+  /* vertical divider */
   background-color: white;
   height: 40px;
   width: 1px;
+}
+
+@media (max-width: 768px) {
+  /* horizontal divider */
+  .navbar .nav .navbar-divider {
+    height: 1px;
+    width: 100%;
+  }
 }
 
 #navbar-profile {

--- a/assets/styles/theme.css
+++ b/assets/styles/theme.css
@@ -394,7 +394,7 @@ footer a {
   background-color: #D63A25;
 }
 
-.navbar .nav .divider-vertical {
+.navbar .nav .navbar-divider {
   background-color: #dd361a;
 }
 .navbar-brand,


### PR DESCRIPTION
Fixes #859 

Simply switches to a horizontal divider when in narrow/mobile mode.

![navbar](https://cloud.githubusercontent.com/assets/6355971/8286789/a7adf860-18d9-11e5-987b-35a2de67ea80.png)
