### PR TITLE
added admin policy to TagEntity controller

### DIFF
--- a/config/policies.js
+++ b/config/policies.js
@@ -147,7 +147,9 @@ module.exports.policies = {
 
   TagEntityController : {
     // Purely for administrative functions
-    '*': 'authenticated'
+    '*': ['authenticated'],
+    'update': ['authenticated', 'admin'],
+    'destroy': ['authenticated', 'admin']
   },
 
   TaskController : {


### PR DESCRIPTION
Prevents non-admin users from modifying existing tags in the database. [It was noted](https://github.com/18F/midas/blob/devel/api/controllers/TagEntityController.js#L11-L15) that this was intended to be secured, and only accessible by admins.