### PR TITLE
Copy local image assets to tmp static file directory on build

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -95,7 +95,7 @@ module.exports = function (grunt) {
         {
           expand: true,
           cwd: './assets',
-          src: ['build/**/*', 'js/vendor/**/*', 'images/**/*', 'locales/**/*', 'data/**/*'],
+          src: ['build/**/*', 'js/vendor/**/*', 'images/**/*', 'locales/**/*', 'data/**/*', 'uploads/**/*'],
           dest: '.tmp/public'
         }
         ]


### PR DESCRIPTION
When uploading files to `assets/uploads`, they need to be copied to `.tmp/public` to be served. This copies them as part of the default grunt task in charge of copying assets. For production, this isn't an issue, because we serve assets from S3.