### PR TITLE
fixed ownerOrAdmin policy for volunteer destroy

### DIFF
--- a/api/policies/ownerOrAdmin.js
+++ b/api/policies/ownerOrAdmin.js
@@ -8,10 +8,6 @@ module.exports = function addUserId (req, res, next) {
   if (req.isOwner || req.user[0].isAdmin) {
     return next();
   }
-  // if this isn't a project or task request, pass through
-  if (_.isUndefined(req.proj) && _.isUndefined(req.task)) {
-    return next();
-  }
   // Otherwise not allowed.
   return res.send(403, { message: "Not authorized." });
 };

--- a/api/policies/volunteer.js
+++ b/api/policies/volunteer.js
@@ -1,13 +1,19 @@
 /**
-* Determines whether the logged in user owns this volunteer
+* Determines whether the logged in user has rights to this volunteer
 */
 module.exports = function volunteer (req, res, next) {
 
   Volunteer.findOneById(req.params.id, function (err, v) {
     if (err || !v) { return res.send(400, { message: 'Error finding volunteer status'}); }
 
-    // Volunteer must be owned by the user (used by ownerOrAdmin() )
-    req.isOwner = (v.userId == req.user[0].id);
-    return next();
+    Task.findOneById(v.taskId, function (err, t) {
+        if (err || !t) { return res.send(400, { message: 'Error finding corresponding task for volunteer'}); }
+
+        // Volunteer is owned by either the user that volunteered,
+        // or the owner of the task. (used by ownerOrAdmin() )
+        req.isOwner = (v.userId == req.user[0].id) ||
+                      (t.userId == req.user[0].id);
+        return next();
+    });
   });
 };

--- a/api/policies/volunteer.js
+++ b/api/policies/volunteer.js
@@ -1,0 +1,13 @@
+/**
+* Determines whether the logged in user owns this volunteer
+*/
+module.exports = function volunteer (req, res, next) {
+
+  Volunteer.findOneById(req.params.id, function (err, v) {
+    if (err || !v) { return res.send(400, { message: 'Error finding volunteer status'}); }
+
+    // Volunteer must be owned by the user (used by ownerOrAdmin() )
+    req.isOwner = (v.userId == req.user[0].id);
+    return next();
+  });
+};

--- a/config/policies.js
+++ b/config/policies.js
@@ -118,7 +118,7 @@ module.exports.policies = {
   VolunteerController : {
     '*': false,
     'create': ['authenticated', 'requireUserId', 'addUserId'],
-    'destroy': ['authenticated', 'requireId', 'ownerOrAdmin'],
+    'destroy': ['authenticated', 'requireUserId', 'requireId', 'volunteer', 'ownerOrAdmin'],
   },
 
   EventController : {


### PR DESCRIPTION
Plugs another API hole where any user could delete volunteers. The `ownerOrAdmin` policy was already present, but it passes requests that [aren't tasks or projects](https://github.com/18F/midas/blob/devel/api/policies/ownerOrAdmin.js#L11-L14), and the `isOwner` flag was never set. This PR adds a `volunteer` policy that sets the `isOwner` flag, and removes the project/task clause from `ownerOrAdmin`.

**Question**
Would it be better to remove `ownerOrAdmin` in favor of individual `ownsTask`, `ownsProject`, policies? The actual ID checks (to set the isOwner flag) are endpoint-specific, so it might be safer to have this done in one policy, rather than require a dependent policy to set flags.