### PR TITLE
Download files with the correct filename, rather than file ID

### DIFF
--- a/assets/js/backbone/apps/attachment/templates/attachment_item_template.html
+++ b/assets/js/backbone/apps/attachment/templates/attachment_item_template.html
@@ -3,7 +3,7 @@
     <span class="file-tag c3-bg white">file</span>
   </td>
   <td class="attachment-name">
-    <a href="/api/file/get/<%- a.file.id %>" class="file-link" data-id="<%- a.file.id %>">
+    <a href="/api/file/get/<%- a.file.id %>" class="file-link" data-id="<%- a.file.id %>" download="<%- a.file.name %>">
       <%- a.file.name %>
       <% if (user && ((a.userId == a.userId) || owner)) { %>
       <a href="#" class="file-delete" data-id="<%- a.id %>"><i class="fa fa-remove"></i></a>


### PR DESCRIPTION
simply adds the `download` attribute to the link, so that files aren't downloaded with names like `2`, and `38`.