### PR TITLE
Fixed ajax error for world data in Firefox

### DIFF
--- a/assets/js/backbone/apps/people/controllers/people_map_controller.js
+++ b/assets/js/backbone/apps/people/controllers/people_map_controller.js
@@ -28,7 +28,7 @@ PeopleMap.Controller = BaseController.extend({
       })
     });
     gatherData.push(function (cb) {
-      d3.json("data/world-110m.json", function (err, world) {
+      d3.json("/data/world-110m.json", function (err, world) {
         if (err) {
           cb(err);
         } else {


### PR DESCRIPTION
In Firefox and Chrome, the D3 ajax request on the `/people/` page for `world-110m.json` can fail. This is because it requests

`http://localhost:1337/people/data/world-110m.json`

instead of,

`http://localhost:1337/data/world-110m.json`

This only happens when there is a trailing slash in the page URL (`http://localhost:1337/people/`). The solution was simply to make the path relative to the root, which now operates correctly. Tested in Firefox 38 and Chrome 43.

**To reproduce**
- point Firefox or Chrome at `http://localhost:1337/people/`. *(Note the trailing slash)*
- The map will fail to load, and the network inspector will show a 404'd request for `world-110m.json`