### PR TITLE
Remove obsolete comment about TagEntity controller

### DIFF
--- a/api/controllers/TagEntityController.js
+++ b/api/controllers/TagEntityController.js
@@ -7,12 +7,4 @@
 
 module.exports = {
 
-  /**
-   * This controller is purely for administrative use to
-   * add/remove/list/etc tag entities.
-   *
-   * The security policies prevent non-Administrator users
-   * from accessing this controller.
-   */
-
 };


### PR DESCRIPTION
Since the tag refactor, we do allow authenticated users to create new TagEntities

Follows up on #875