### PR TITLE
Slight refactor of the TagFactory

### DIFF
--- a/assets/js/backbone/apps/admin/views/admin_tag_view.js
+++ b/assets/js/backbone/apps/admin/views/admin_tag_view.js
@@ -37,44 +37,16 @@ var AdminTagView = Backbone.View.extend({
 
   tagSelector: function(type) {
     var self = this;
-    $('#' + type).select2({
-      placeholder: 'Search for a tag',
-      minimumInputLength: 2,
-      formatResult: function (obj, container, query) {
-        return obj.name;
-      },
-      formatSelection: function (obj, container, query) {
-        return obj.name;
-      },
-      createSearchChoice: function (term, values) {
-        var vals = values.map(function(value) {
-          return value.value.toLowerCase();
-        });
-        return (vals.indexOf(term.toLowerCase()) >=0) ? false : {
-          unmatched: true,
-          tagType: type,
-          id: term,
-          value: term,
-          name: "<b>"+term+"</b> <i>click to create a new tag with this value</i>"
-        };
-      },
-      ajax: {
-        url: '/api/ac/tag',
-        dataType: 'json',
-        data: function (term) {
-          return {
-            type: type,
-            q: term
-          };
-        },
-        results: function (data) {
-          return { results: data };
-        }
-      }
-    }).on('change', function(e) {
+
+    var $sel = this.tagFactory.createTagDropDown({
+      type: type,
+      selector: "#" + type,
+    })
+
+    $sel.on('change', function(e) {
       var $el = self.$(e.currentTarget);
       self.tagFactory.addTagEntities(e.added, self, function() {
-        $('#' + type).select2('data', null);
+        $sel.select2('data', null);
         if (e.added && e.added.value === e.added.id) {
           $el.next('.form-status').text('Added tag: ' + e.added.value);
         } else {
@@ -82,6 +54,7 @@ var AdminTagView = Backbone.View.extend({
         }
       });
     });
+
   },
 
   cleanup: function () {

--- a/assets/js/backbone/apps/profiles/show/views/profile_show_view.js
+++ b/assets/js/backbone/apps/profiles/show/views/profile_show_view.js
@@ -26,10 +26,9 @@ var ProfileShowView = Backbone.View.extend({
     "click .link-backbone"       : linkBackbone,
     "click #profile-cancel"      : "profileCancel",
     "click #like-button"         : "like",
-    "keyup #name, #title, #bio"  : "fieldModified",
-    "keyup"                      : "checkName",
-    "change"                     : "checkName",
-    "blur"                       : "checkName",
+    "keyup"                      : "fieldModified",
+    "change"                     : "fieldModified",
+    "blur"                       : "fieldModified",
     "click .removeAuth"          : "removeAuth"
   },
 
@@ -208,14 +207,6 @@ var ProfileShowView = Backbone.View.extend({
   initializeForm: function() {
     var self = this;
 
-    $("#topics").on('change', function (e) {
-      self.model.trigger("profile:input:changed", e);
-    });
-
-    $("#skills").on('change', function (e) {
-      self.model.trigger("profile:input:changed", e);
-    });
-
     this.listenTo(self.model, "profile:save:success", function (data) {
       // Bootstrap .button() has execution order issue since it
       // uses setTimeout to change the text of buttons.
@@ -263,11 +254,6 @@ var ProfileShowView = Backbone.View.extend({
 
   initializeSelect2: function () {
     var self = this;
-
-    var formatResult = function (object, container, query) {
-      return object.name;
-    };
-
     var modelJson = this.model.toJSON();
 
     /*
@@ -292,22 +278,6 @@ var ProfileShowView = Backbone.View.extend({
       data:        modelJson.agency,
       width:       "100%",
     });
-
-    $("#topics").on('change', function (e) {
-      self.model.trigger("profile:input:changed", e);
-    });
-
-    $("#skills").on('change', function (e) {
-      self.model.trigger("profile:input:changed", e);
-    });
-
-    $("#company").on('change', function (e) {
-      self.model.trigger("profile:input:changed", e);
-    });
-
-    $("#location").on('change', function (e) {
-      self.model.trigger("profile:input:changed", e);
-    });
   },
 
   initializeTextArea: function () {
@@ -323,16 +293,12 @@ var ProfileShowView = Backbone.View.extend({
   },
 
   fieldModified: function (e) {
-    this.model.trigger("profile:input:changed", e);
-  },
 
-  checkName: function (e) {
-    var name = this.$("#name").val();
-    if (name && name !== '') {
-      $("#name").closest(".form-group").find(".help-block").hide();
-    } else {
-      $("#name").closest(".form-group").find(".help-block").show();
-    }
+    //check that the name isn't a null string
+    var $help = this.$("#name").closest(".form-group").find(".help-block")
+    $help.toggle( this.$("#name").val() === '' )
+
+    this.model.trigger("profile:input:changed", e);
   },
 
   profileCancel: function (e) {

--- a/assets/js/backbone/apps/profiles/show/views/profile_show_view.js
+++ b/assets/js/backbone/apps/profiles/show/views/profile_show_view.js
@@ -270,36 +270,28 @@ var ProfileShowView = Backbone.View.extend({
 
     var modelJson = this.model.toJSON();
 
+    /*
+      The location and company selectors differ from the
+      defaults in tag_show_view, so they are explicitly
+      created here (with different HTML IDs than normal,
+      to avoid conflicts).
+    */
     this.tagFactory.createTagDropDown({
-      type: "location",
-      selector: "#location",
-      multiple: false,
-      data: modelJson.location,
-      width: "100%"
+      type:        "location",
+      selector:    "#location",
+      multiple:    false,
+      data:        modelJson.location,
+      width:       "100%"
     });
 
-    $("#company").select2({
-      placeholder: 'Select an Agency',
-      formatResult: formatResult,
-      formatSelection: formatResult,
-      minimumInputLength: 2,
-      ajax: {
-        url: '/api/ac/tag',
-        dataType: 'json',
-        data: function (term) {
-          return {
-            type: 'agency',
-            q: term
-          };
-        },
-        results: function (data) {
-          return { results: data };
-        }
-      }
+    this.tagFactory.createTagDropDown({
+      type:        "agency",
+      selector:    "#company",
+      multiple:    false,
+      allowCreate: false,
+      data:        modelJson.agency,
+      width:       "100%",
     });
-    if (modelJson.agency) {
-      $("#company").select2('data', modelJson.agency);
-    }
 
     $("#topics").on('change', function (e) {
       self.model.trigger("profile:input:changed", e);
@@ -313,9 +305,6 @@ var ProfileShowView = Backbone.View.extend({
       self.model.trigger("profile:input:changed", e);
     });
 
-    // if (modelJson.location) {
-    //   $("#location").select2('data', modelJson.location);
-    // }
     $("#location").on('change', function (e) {
       self.model.trigger("profile:input:changed", e);
     });
@@ -371,17 +360,15 @@ var ProfileShowView = Backbone.View.extend({
           $("#company").select2('data'),
           $("#tag_topic").select2('data'),
           $("#tag_skill").select2('data'),
-          // $("#tag_location").select2('data'),
-          $("#location").select2('data'),
-          $("#tag_agency").select2('data')
+          $("#location").select2('data')
         ),
         modelTags = _(this.model.get('tags')).filter(function(tag) {
           return (tag.type !== 'agency' && tag.type !== 'location');
         }),
         data = {
-          name: $("#name").val(),
+          name:  $("#name").val(),
           title: $("#title").val(),
-          bio: $("#bio").val(),
+          bio:   $("#bio").val(),
         },
         email = this.model.get('emails')[0],
         self = this,

--- a/assets/js/backbone/apps/profiles/show/views/profile_show_view.js
+++ b/assets/js/backbone/apps/profiles/show/views/profile_show_view.js
@@ -270,40 +270,12 @@ var ProfileShowView = Backbone.View.extend({
 
     var modelJson = this.model.toJSON();
 
-    var locationSettings = {
-      placeholder: 'Select a Location',
-      formatResult: formatResult,
-      formatSelection: formatResult,
-      minimumInputLength: 1,
-      data: [ location ],
-      createSearchChoice: function (term, values) {
-        var vals = values.map(function(value) {
-          return value.value.toLowerCase();
-        });
-
-        //unmatched = true is the flag for saving these "new" tags to tagEntity when the opp is saved
-        return (vals.indexOf(term.toLowerCase()) >=0) ? false : {
-          tagType: 'location',
-          id: term,
-          value: term,
-          temp: true,
-          name: "<b>"+term+"</b> <i>search for this location</i>"
-        };
-      },
-      ajax: {
-        url: '/api/ac/tag',
-        dataType: 'json',
-        data: function (term) {
-          return {
-            type: 'location',
-            q: term
-          };
-        },
-        results: function (data) {
-          return { results: data };
-        }
-      }
-    };
+    this.tagFactory.createTagDropDown({
+      type: "location",
+      selector: "#location",
+      data: modelJson.location,
+      width: "100%"
+    });
 
     $("#company").select2({
       placeholder: 'Select an Agency',
@@ -339,64 +311,10 @@ var ProfileShowView = Backbone.View.extend({
     $("#company").on('change', function (e) {
       self.model.trigger("profile:input:changed", e);
     });
-    $('#location').select2(locationSettings).on('select2-selecting', function(e) {
-      var $el = self.$(e.currentTarget),
-          el = this;
-      if (e.choice.temp) {
-        this.temp = true;
-        $('#location').select2('data', e.choice.name);
-        $.get('/api/location/suggest?q=' + e.choice.value, function(d) {
-          d = _(d).map(function(item) {
-            return {
-              id: item.name,
-              text: item.name,
-              name: item.name,
-              unmatched: true,
-              tagType: 'location',
-              data: _(item).omit('name')
-            };
-          });
-          el.reload = true;
-          el.open = true;
-          $('#location').select2({
-            data: d,
-            formatResult: function (obj) { return obj.name; },
-            formatSelection: function (obj) { return obj.name; },
-            createSearchChoice: function (term, values) {
-              if (!values.some(function (v) {
-                  return (v.name.toLowerCase().indexOf(term.toLowerCase()) >= 0);
-                })) {
-                return {
-                  tagType: 'location',
-                  id: term,
-                  value: term,
-                  temp: true,
-                  name: "<b>" + term + "</b> <i>search for this location</i>"
-                };
-              }
-            }
-          }).select2('open');
-        });
-      } else {
-        delete this.temp;
-      }
-    }).on('select2-open', function(e) {
-      if (!this.reload && this.open) {
-        delete this.open;
-        delete this.temp;
-        var cache = $("#location").select2('data');
-        setTimeout(function() {
-          $("#location").select2(locationSettings)
-            .select2('data', cache)
-            .select2('open');
-        }, 0);
-      } else if (this.reload && this.open) {
-        delete this.reload;
-      }
-    });
-    if (modelJson.location) {
-      $("#location").select2('data', modelJson.location);
-    }
+
+    // if (modelJson.location) {
+    //   $("#location").select2('data', modelJson.location);
+    // }
     $("#location").on('change', function (e) {
       self.model.trigger("profile:input:changed", e);
     });
@@ -452,7 +370,7 @@ var ProfileShowView = Backbone.View.extend({
           $("#company").select2('data'),
           $("#tag_topic").select2('data'),
           $("#tag_skill").select2('data'),
-          $("#tag_location").select2('data'),
+          // $("#tag_location").select2('data'),
           $("#location").select2('data'),
           $("#tag_agency").select2('data')
         ),

--- a/assets/js/backbone/apps/profiles/show/views/profile_show_view.js
+++ b/assets/js/backbone/apps/profiles/show/views/profile_show_view.js
@@ -295,8 +295,8 @@ var ProfileShowView = Backbone.View.extend({
   fieldModified: function (e) {
 
     //check that the name isn't a null string
-    var $help = this.$("#name").closest(".form-group").find(".help-block")
-    $help.toggle( this.$("#name").val() === '' )
+    var $help = this.$("#name").closest(".form-group").find(".help-block");
+    $help.toggle( this.$("#name").val() === "" );
 
     this.model.trigger("profile:input:changed", e);
   },

--- a/assets/js/backbone/apps/profiles/show/views/profile_show_view.js
+++ b/assets/js/backbone/apps/profiles/show/views/profile_show_view.js
@@ -273,6 +273,7 @@ var ProfileShowView = Backbone.View.extend({
     this.tagFactory.createTagDropDown({
       type: "location",
       selector: "#location",
+      multiple: false,
       data: modelJson.location,
       width: "100%"
     });

--- a/assets/js/backbone/apps/tag/show/views/tag_show_view.js
+++ b/assets/js/backbone/apps/tag/show/views/tag_show_view.js
@@ -55,15 +55,32 @@ var TagShowView = Backbone.View.extend({
     var self = this;
 
     self.tagFactory.createTagDropDown({
-      type:"skill",selector:"#tag_skill",width: "100%",tokenSeparators: [","]
+      type:"skill",
+      selector:"#tag_skill",
+      width: "100%",
+      tokenSeparators: [","]
     });
 
     self.tagFactory.createTagDropDown({
-      type:"topic",selector:"#tag_topic",width: "100%",tokenSeparators: [","]
+      type:"topic",
+      selector:"#tag_topic",
+      width: "100%",
+      tokenSeparators: [","]
     });
 
-    self.tagFactory.createTagDropDown({type:"location",selector:"#tag_location",width: "100%"});
-    self.tagFactory.createTagDropDown({type:"agency",selector:"#tag_agency",width: "100%"});
+    self.tagFactory.createTagDropDown({
+      type:"location",
+      selector:"#tag_location",
+      width: "100%",
+      multiple: true,
+    });
+
+    self.tagFactory.createTagDropDown({
+      type:"agency",
+      selector:"#tag_agency",
+      width: "100%"
+    });
+
     self.model.trigger("profile:input:changed");
   },
 

--- a/assets/js/backbone/apps/tag/show/views/tag_show_view.js
+++ b/assets/js/backbone/apps/tag/show/views/tag_show_view.js
@@ -20,7 +20,6 @@ var TagShowView = Backbone.View.extend({
   /*
     @param {Object}  options
     @param {String}  options.target   - key for looking up tag-type sets from the TagConfig (profile|task|project)
-    @param {String}  options.targetId - not used
     @param {Boolean} options.edit     - whether or not to display the tag editor
   */
   initialize: function (options) {

--- a/assets/js/backbone/apps/tag/show/views/tag_show_view.js
+++ b/assets/js/backbone/apps/tag/show/views/tag_show_view.js
@@ -71,8 +71,7 @@ var TagShowView = Backbone.View.extend({
     self.tagFactory.createTagDropDown({
       type:"location",
       selector:"#tag_location",
-      width: "100%",
-      multiple: true,
+      width: "100%"
     });
 
     self.tagFactory.createTagDropDown({

--- a/assets/js/backbone/apps/tag/show/views/tag_show_view.js
+++ b/assets/js/backbone/apps/tag/show/views/tag_show_view.js
@@ -108,50 +108,6 @@ var TagShowView = Backbone.View.extend({
     };
 
     _(this.model.get('tags')).each(renderTag);
-    // Initialize Select2 for Administrative Functions
-    var formatResult = function (object, container, query) {
-      return '<i class="' + tagIcon[object.type] + '"></i> ' + object.name;
-    };
-
-    $("#input-tags").select2({
-      placeholder: 'Add tags',
-      multiple: true,
-      formatResult: formatResult,
-      formatSelection: formatResult,
-      ajax: {
-        url: '/api/ac/tag',
-        dataType: 'json',
-        data: function (term) {
-          return {
-            type: TagConfig[self.target].join(),
-            q: term
-          };
-        },
-        results: function (data) {
-          return { results: data };
-        }
-      }
-    });
-
-    // New tags added in to the DB via the modal
-    this.listenTo(this.model, this.target + ":tag:new", function (data) {
-      // Destory modal
-      $(".modal").modal('hide');
-      // Add tag into the data list
-      var s2data = $("#input-tags").select2("data");
-      s2data.push(data);
-      $("#input-tags").select2("data", s2data);
-    });
-
-    // Tags saved using the select2 dialog
-    this.listenTo(this.model, this.target + ":tag:save", function (data) {
-      for (var i = 0; i < data.length; i++) {
-        if (!data[i].existing) {
-          renderTag(data[i]);
-        }
-      }
-      $("#input-tags").select2("val", "");
-    });
 
     this.listenTo(this.model, this.target + ":tag:delete", function (e) {
       if ($(e.currentTarget).parent('li').siblings().length == 1) {

--- a/assets/js/backbone/apps/tag/show/views/tag_show_view.js
+++ b/assets/js/backbone/apps/tag/show/views/tag_show_view.js
@@ -17,6 +17,12 @@ var TagShowView = Backbone.View.extend({
     "click .tag-delete"     : "deleteTag"
   },
 
+  /*
+    @param {Object}  options
+    @param {String}  options.target   - key for looking up tag-type sets from the TagConfig (profile|task|project)
+    @param {String}  options.targetId - not used
+    @param {Boolean} options.edit     - whether or not to display the tag editor
+  */
   initialize: function (options) {
     this.options = options;
     this.model = options.model;

--- a/assets/js/backbone/apps/tasks/edit/views/task_edit_form_view.js
+++ b/assets/js/backbone/apps/tasks/edit/views/task_edit_form_view.js
@@ -137,23 +137,27 @@ var TaskEditFormView = Backbone.View.extend({
     }
 
     this.tagFactory.createTagDropDown({
-      type:"skill",selector:"#task_tag_skills",width: "100%", tokenSeparators: [","]
+      type: "skill",
+      selector: "#task_tag_skills",
+      width: "100%",
+      tokenSeparators: [","],
+      data: this.data['madlibTags'].skill
     });
-    if (this.data['madlibTags'].skill) {
-      this.$("#task_tag_skills").select2('data', this.data['madlibTags'].skill);
-    }
 
     this.tagFactory.createTagDropDown({
-      type:"topic", selector: "#task_tag_topics", width: "100%", tokenSeparators: [","]
+      type: "topic",
+      selector: "#task_tag_topics",
+      width: "100%",
+      tokenSeparators: [","],
+      data: this.data['madlibTags'].topic
     });
-    if (this.data['madlibTags'].topic) {
-      this.$("#task_tag_topics").select2('data', this.data['madlibTags'].topic);
-    }
 
-    this.tagFactory.createTagDropDown({type:"location",selector:"#task_tag_location",width: "100%"});
-    if (this.data['madlibTags'].location) {
-      this.$("#task_tag_location").select2('data', this.data['madlibTags'].location);
-    }
+    this.tagFactory.createTagDropDown({
+      type: "location",
+      selector: "#task_tag_location",
+      width: "100%",
+      data: this.data['madlibTags'].location
+    });
 
     $("#skills-required").select2({
       placeholder: "required/not-required",

--- a/assets/js/backbone/components/tag_factory.js
+++ b/assets/js/backbone/components/tag_factory.js
@@ -65,6 +65,8 @@ TagFactory = BaseComponent.extend({
     @param {Boolean}  options.allowCreate=true   - Whether a `createSearchChoice` option will be given
     @param {String[]} options.tokenSeparators=[] - Array of valid tag delimeters
     @param {*}        options.data=undefined     - The initial data loaded into the select2 element
+
+    @returns {jQuery element}                    - The initialized jQuery element selected by options.selector
   */
   createTagDropDown: function(options) {
 
@@ -211,6 +213,8 @@ TagFactory = BaseComponent.extend({
     if(options.data) {
       $sel.select2('data', options.data);
     }
+
+    return $sel;
   },
 
 });

--- a/assets/js/backbone/components/tag_factory.js
+++ b/assets/js/backbone/components/tag_factory.js
@@ -111,7 +111,14 @@ TagFactory = BaseComponent.extend({
 
     //if requested, give users the option to create new
     if(options.allowCreate) {
-      settings.createSearchChoice = function (term) {
+      settings.createSearchChoice = function (term, values) {
+        values = values.map(function(v) {
+          return v.value.toLowerCase();
+        });
+
+        if (values.indexOf(term.toLowerCase()) >= 0)
+          return false; //don't prompt to "add new" if it already exists
+
         //unmatched = true is the flag for saving these "new" tags to tagEntity when the opp is saved
         return {
           unmatched: true,

--- a/assets/js/backbone/components/tag_factory.js
+++ b/assets/js/backbone/components/tag_factory.js
@@ -71,7 +71,7 @@ TagFactory = BaseComponent.extend({
     //location tags get special treatment
     var isLocation = (options.type === 'location')
 
-    //have to check these first, to allow False values to override the default True
+    //have to check these beforehand to allow False values to override the default True
     options.multiple    = (options.multiple    !== undefined ? options.multiple    : true);
     options.allowCreate = (options.allowCreate !== undefined ? options.allowCreate : true);
 
@@ -134,7 +134,6 @@ TagFactory = BaseComponent.extend({
     //event handlers
     $sel.on("select2-selecting", function (e) {
       if (e.choice.tagType === 'location') {
-
         if (e.choice.temp) {
           this.temp = true;
           e.choice.name = '<em>Searching for <strong>' + e.choice.value + '</strong></em>';
@@ -144,7 +143,6 @@ TagFactory = BaseComponent.extend({
             d = _(d).map(function(item) {
               return {
                 id: item.name,
-                text: item.name,
                 name: item.name,
                 unmatched: true,
                 tagType: 'location',
@@ -153,8 +151,9 @@ TagFactory = BaseComponent.extend({
             });
             this.cache = $sel.select2('data');
             if(settings.multiple) {
+              //remove the "Searching for..." text from multi-select boxes
               this.cache = _.reject(this.cache, function(item) {
-                return (item.name.indexOf('<em>Searching for <strong>') >= 0);
+                return (item.name.indexOf('Searching') >= 0);
               });
             }
             $sel.select2({


### PR DESCRIPTION
Frontend changes only

I was about ready to start adding new tag fields to the profile page for my client, when I noticed a lot of redundant code regarding Tag dropdowns. This PR helps keep things DRY by using the TagFactory where complicated `select2` calls were before. To do this, a handful of new options and existing code was added to the TagFactory.

80% of the TagFactory code you see being changed is actually just code moving from place to place. There were various versions of the same chunks of `select2` code floating around inside Midas. I have gathered them into the TagFactory, and provided extra options where neccessary. The remaining calls to `select2` are either trivial, or transact with endpoints other than `/api/ac/tag` (for instance, the `task_edit_form_view` uses `/api/ac/user` for setting task ownership). My hope was to make the TagFactory a bit better at its job.

## Change summary
- New options for `tagFactory.createTagDropDown` (also added a doc comment to explain it all):
  - `multiple`: whether or not to allow multiple tags
  - `allowCreate`: while most inputs allow for new TagEntity creation, a few do not, such as the `Agency` field.
  - `data`: sets the initial data of the tag selector
- `tagFactory.createTagDropDown` now returns the constructed `select2` jQuery element, selected by `options.selector`. 
- Correctly handles location tags in "single mode" (`multiple=false`), allowing it to be used on the Profile page.
- When a tag already exists, do *not* prompt to "create new" (fixes #881)
- Replaced redundant `select2` calls with `tagFactory.createTagDropDown({ ... })`. (Also plugs a few lingering sanitization holes by sharing common escapement code). Pages where this happened:
  - `/profile/:id` agency, location
  - `/admin/tag` agency, skill, topic
- Updated existing `tagFactory.createTagDropDown({ ... })` calls to make use of the new options.
  - `/tasks/:id` skill, topic, location
  - `tag_show_view.js` agency, skill, topic, location (so, pretty much everywhere...)
- Removed an old [`createDiff`](https://github.com/18F/midas/blob/devel/assets/js/backbone/components/tag_factory.js#L154-L187) function that was no longer used. Please correct me if I'm wrong. My search for calls to this function came up null, and it seems to assemble tag structures that aren't used anymore. Instead of being diffed, tags are simply sent in bulk with model updates, with existing tags referenced by ID (see [here](https://github.com/18F/midas/blob/devel/assets/js/backbone/apps/profiles/show/views/profile_show_view.js#L469-L479) for the current way this is done).
- Removed old ["administrative" tag code](https://github.com/18F/midas/blob/devel/assets/js/backbone/apps/tag/show/views/tag_show_view.js#L90-L133). The `#input-tags` selector actually returns empty, and silently fails anyway. I could not find reference to `input-tags` or any of those events being broadcast (`<target>:tag:new` and `<target>:tag:save`). I also saw no functional difference, but again, please correct me if I'm wrong.
- The Profile page now correctly registers `change` events on the Tag dropdowns.

I'd really appreciate a thorough review on this one, since I've been rearranging some grey matter. Midas *should* be functionally identical to the way it was before, with the exception of the fix for #881, and the patching of a few escapement problems.

Tested in Firefox 38 and Chrome 43