### PR TITLE
Prevent users from updating comments they don't own

### DIFF
--- a/api/policies/comment.js
+++ b/api/policies/comment.js
@@ -1,0 +1,13 @@
+/**
+* Determines whether the logged in user owns this comment
+*/
+module.exports = function comment (req, res, next) {
+
+  Comment.findOneById(req.params.id, function (err, c) {
+    if (err || !c) { return res.send(400, { message: 'Error finding comment'}); }
+
+    // Volunteer must be owned by the user (used by ownerOrAdmin() )
+    req.isOwner = (c.userId == req.user[0].id);
+    return next();
+  });
+};

--- a/config/policies.js
+++ b/config/policies.js
@@ -139,7 +139,7 @@ module.exports.policies = {
     'find': false,
     'findOne': false,
     'create': ['authenticated', 'requireUserId', 'addUserId', 'projectId', 'taskId'],
-    'update': ['authenticated', 'requireUserId', 'projectId', 'taskId'],
+    'update': ['authenticated', 'requireUserId', 'projectId', 'taskId', 'comment', 'ownerOrAdmin'],
     'destroy': ['authenticated', 'requireUserId', 'requireId', 'admin'],
     'findAllByProjectId': ['authenticated', 'requireId', 'project'],
     'findAllByTaskId': ['authenticated', 'requireId', 'task']


### PR DESCRIPTION
Previously, comment UPDATE requests were processed without question. With this policy, only comment owners, and admins are allowed to alter existing comments.