### PR TITLE
moved error check to prevent server crash

### DIFF
--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -49,9 +49,9 @@ module.exports = {
       reqId = req.user[0].id;
     }
     sails.services.utils.user.getUser(req.route.params.id, reqId, function (err, user) {
+      if (err) { return res.send(400, { message: err }); }
       // prune out any info you don't want to be public here.
       if (reqId !== req.route.params.id) user.username = null;
-      if (err) { return res.send(400, { message: err }); }
       sails.log.debug('User Get:', user);
       res.send(user);
     });


### PR DESCRIPTION
Prevents problems where `/user/info/:id` is accessed with an invalid user ID, and returns an error. This error (produced by `services.utils.user.getUser()`) simply was not being handled soon enough.

Here's an example crash:

```
/var/lib/openshift/5570cea95973cad867000020/app-root/runtime/repo/api/controllers/UserController.js:53
      if (reqId !== req.route.params.id) user.username = null;
                                                       ^
TypeError: Cannot set property 'username' of null
    at /var/lib/openshift/5570cea95973cad867000020/app-root/runtime/repo/api/controllers/UserController.js:53:56
    at /var/lib/openshift/5570cea95973cad867000020/app-root/runtime/repo/api/services/utils/user.js:711:34
    at wrapper (/var/lib/openshift/5570cea95973cad867000020/app-root/runtime/repo/node_modules/sails/node_modules/waterline/node_modules/lodash/index.js:3602:19)
    at applyInOriginalCtx (/var/lib/openshift/5570cea95973cad867000020/app-root/runtime/repo/node_modules/sails/node_modules/waterline/lib/waterline/utils/normalize.js:421:80)
    at wrappedCallback (/var/lib/openshift/5570cea95973cad867000020/app-root/runtime/repo/node_modules/sails/node_modules/waterline/lib/waterline/utils/normalize.js:320:18)
    at _normalizeCallback.callback.success (/var/lib/openshift/5570cea95973cad867000020/app-root/runtime/repo/node_modules/sails/node_modules/waterline/node_modules/switchback/lib/normalize.js:33:31)
    at _switch (/var/lib/openshift/5570cea95973cad867000020/app-root/runtime/repo/node_modules/sails/node_modules/waterline/node_modules/switchback/lib/factory.js:48:28)
    at returnResults (/var/lib/openshift/5570cea95973cad867000020/app-root/runtime/repo/node_modules/sails/node_modules/waterline/lib/waterline/query/finders/basic.js:170:9)
    at /var/lib/openshift/5570cea95973cad867000020/app-root/runtime/repo/node_modules/sails/node_modules/waterline/lib/waterline/query/finders/basic.js:81:16
    at /var/lib/openshift/5570cea95973cad867000020/app-root/runtime/repo/node_modules/sails/node_modules/waterline/lib/waterline/query/finders/operations.js:77:45
    at wrapper (/var/lib/openshift/5570cea95973cad867000020/app-root/runtime/repo/node_modules/sails/node_modules/waterline/node_modules/lodash/index.js:3602:19)
    at applyInOriginalCtx (/var/lib/openshift/5570cea95973cad867000020/app-root/runtime/repo/node_modules/sails/node_modules/waterline/lib/waterline/utils/normalize.js:421:80)
    at wrappedCallback (/var/lib/openshift/5570cea95973cad867000020/app-root/runtime/repo/node_modules/sails/node_modules/waterline/lib/waterline/utils/normalize.js:320:18)
    at _normalizeCallback.callback.success (/var/lib/openshift/5570cea95973cad867000020/app-root/runtime/repo/node_modules/sails/node_modules/waterline/node_modules/switchback/lib/normalize.js:33:31)
    at _switch (/var/lib/openshift/5570cea95973cad867000020/app-root/runtime/repo/node_modules/sails/node_modules/waterline/node_modules/switchback/lib/factory.js:48:28)
    at /var/lib/openshift/5570cea95973cad867000020/app-root/runtime/repo/node_modules/sails-postgresql/lib/adapter.js:1162:16
DEBUG: Program node app.js exited with code 8
DEBUG: Starting child process with 'node app.js'
```