### PR TITLE
Add script for reviewing and deleting duplicate users

### DIFF
--- a/tools/postgres/removeDuplicateUsers.sql
+++ b/tools/postgres/removeDuplicateUsers.sql
@@ -1,0 +1,12 @@
+-- Query for reviewing and removing duplicate users
+-- Modified from https://wiki.postgresql.org/wiki/Deleting_duplicates
+
+-- It prioritizes keeping enabled accounts and those with recent logins
+-- When you're ready to delete, change `SELECT *` to `DELETE`
+
+SELECT * FROM midas_user
+WHERE id IN (SELECT id
+  FROM (SELECT id,
+      ROW_NUMBER() OVER (partition BY username ORDER BY disabled,"updatedAt" DESC) AS rnum
+    FROM midas_user) t
+  WHERE t.rnum > 1);


### PR DESCRIPTION
In theory, users shouldn't have been able to create multiple accounts with the same email address. An unreproducible bug allowed this to happen (#548)

With #902, we now enforce a database constraint on the uniqueness of `midas_user.username`. Before that update can be applied, we need to remove an duplicates that would violate the constraint.

This script produces a list of duplicate accounts to be deleted. Once that list has been reviewed, changing `SELECT *` to `DELETE` in the beginning of the query will remove those records.

Modified from https://wiki.postgresql.org/wiki/Deleting_duplicates

It prioritizes keeping enabled accounts and those with recent logins.