### PR TITLE
Catch for an error when finding tasks with users without tags

### DIFF
--- a/api/services/utils/task.js
+++ b/api/services/utils/task.js
@@ -119,7 +119,7 @@ var findTasks = function (where, cb) {
           var user = _.findWhere(users, { id: task.userId }) || {};
           task.user = {
             name: user.name,
-            agency: user.tags[0]
+            agency: user.tags && user.tags[0]
           };
         });
         return cb(null, tasks);


### PR DESCRIPTION
Just a small patch for something I saw coming up on the staging server.