### PR TITLE
Fix demo script. Simplify init script

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "build": "$npm_package_config_grunt build",
     "start": "node app.js",
     "migrate": "./tools/postgres/init.sh",
-    "init": "mocha test/test.upstart.js --development --recursive test/init",
+    "init": "node test/init/init/init.test.js",
     "demo": "mocha test/test.upstart.js --development --recursive test/demo",
     "import": "cp -v $npm_package_config_dir/exclude.txt exclude.txt | true && rsync -av --exclude-from=exclude.txt $npm_package_config_dir/* .",
     "watch": "source .env | true && nodemon --watch assets --watch api --watch config --watch views -i assets/build -e js,html"

--- a/test/demo/data/utils.js
+++ b/test/demo/data/utils.js
@@ -16,7 +16,7 @@ module.exports = {
       if (err) { return cb(err); }
       // then login
       request.post({ url: conf.url + '/auth/local',
-                     form: { username: username, password: password, json: true },
+                     form: { identifier: username, password: password, json: true },
                    }, function (err, response, body) {
         var getUser = function (cb) {
           request(conf.url + '/user', function (err, response, body) {
@@ -31,7 +31,7 @@ module.exports = {
         if (response.statusCode == 403) {
           // this could be because the user isn't registered; try to register
           // console.log('register user: '+username);
-          request.post({ url: conf.url + '/auth/register',
+          request.post({ url: conf.url + '/auth/local/register',
                          form: { username: username, password: password, json: true },
                        }, function (err, response, body) {
             if (err) { return cb(err); }

--- a/test/init/init/init.test.js
+++ b/test/init/init/init.test.js
@@ -1,50 +1,18 @@
-var assert = require('chai').assert;
-var _ = require('underscore');
-var async = require('async');
-var conf = require('./config');
-var utils = require('../../demo/data/utils');
-var request;
+var conf = require('./config'),
+    async = require('async');
 
-describe('init:', function() {
-
-  before(function(done) {
-    request = utils.init();
-    done();
+require('sails').lift({
+  validateDomains: false,
+  emailProtocol: '',
+  hooks: {
+    grunt: false,
+    sockets: false,
+    pubsub: false,
+    csrf: false
+  }
+}, function(err, sails) {
+  if (err) throw err;
+  async.forEach(conf.tags, TagEntity.create, function(err) {
+    sails.lower();
   });
-
-  it('tags', function (done) {
-    var process = function (tag, done) {
-      utils.tag_find(request, tag.name, tag.type, function (err, t) {
-        if (err) return done(err);
-        // if tag exists, just update it with the tag id
-        if (t) {
-          tag.obj = t;
-          tag.id = t.id;
-          return done(err);
-        }
-        utils.tag_add(request, tag, function (err, t) {
-          tag.obj = t;
-          tag.id = t.id;
-          return done(err);
-        });
-      });
-    };
-
-    utils.login(request, conf.user.username, conf.user.password, function (err) {
-      if (err) return done(err);
-      async.eachSeries(conf.tags, process, function (err) {
-        done(err);
-      });
-    });
-  });
-
-  after(function(done) {
-    utils.user_info(request, function (err, user) {
-      if (err) return done(err);
-      utils.user_disable(request, user, function (err, user) {
-        done(err);
-      });
-    });
-  });
-
 });

--- a/test/test.upstart.js
+++ b/test/test.upstart.js
@@ -45,35 +45,43 @@ before(function(done) {
     sails.localAppURL = localAppURL = ( sails.usingSSL ? 'https' : 'http' ) + '://' + sails.config.host + ':' + sails.config.port + '';
     // save reference for teardown function
 
-    //Add temp userauth
-    sails.models.passport.create({
-      user: 1,
-      provider: 'test',
-      protocol: 'test',
-      accessToken: 'testCode'
-    }, function(err, model) {
-      if (err) return done(err);
+    if (process.env.NODE_ENV === 'test') {
 
-      var adminUser = helperConfig.adminUser;
-
-      // Add an admin user
-      sails.models.user.create({
-        name: adminUser.name,
-        username: adminUser.username,
-        isAdmin: true
-      }, function(err, user) {
+      //Add temp userauth
+      sails.models.passport.create({
+        user: 1,
+        provider: 'test',
+        protocol: 'test',
+        accessToken: 'testCode'
+      }, function(err, model) {
         if (err) return done(err);
-        sails.models.passport.create({
-          protocol: 'local',
-          password: adminUser.password,
-          user: user.id
-        }, function(err) {
+
+        var adminUser = helperConfig.adminUser;
+
+        // Add an admin user
+        sails.models.user.create({
+          name: adminUser.name,
+          username: adminUser.username,
+          isAdmin: true
+        }, function(err, user) {
           if (err) return done(err);
-          done();
+          sails.models.passport.create({
+            protocol: 'local',
+            password: adminUser.password,
+            user: user.id
+          }, function(err) {
+            if (err) return done(err);
+            done();
+          });
         });
       });
-    });
+
+    } else {
+      done();
+    }
+
   });
+
 
 });
 


### PR DESCRIPTION
Uses Sails directly instead of over http, avoiding the need for a temporary admin account.

Fixes the demo script. Note, this script still throws an error at the end but it works for getting the data set. Not worth troubleshooting the error as this should be rewritten too like the init script.