### PR TITLE
Sort time tags in proper order

### DIFF
--- a/config/settings/sources.js
+++ b/config/settings/sources.js
@@ -56,7 +56,8 @@ console.log('Loading... ', __filename);
       ],
       include: [
         'name',
-        'type'
+        'type',
+        'updatedAt'
       ]
     },
     'wikipedia': {


### PR DESCRIPTION
The autocorrect controller generally returns tags sorted by `id` which is great for most of our use cases. However, it was problematic with the `task-time-estimate` tags as the `id` isn't the best indicator of order for those tags.

This PR sorts `tagEntities` returned through auto-correct by the `updatedAt` field instead of `id`. It also updates a previous migration script (`/tools/postgres/migrateOldTags.js`) to make sure to delete old tags and touch the remaining `task-time-estimate` tags so that the `updatedAt` order is the proper order for UI display.

To close #916 