### PR TITLE
Add scripts for importing tasks from Wordpress site

### DIFF
--- a/tools/wordpress-import/convert_xml.rb
+++ b/tools/wordpress-import/convert_xml.rb
@@ -1,0 +1,69 @@
+#!/usr/bin/ruby
+
+# Install gem with `$ gem install reverse_markdown`
+# Run with `$ ruby context_xml.rb [path/to/input_file.xml] > [output_file.json]`
+
+require 'nokogiri'
+require 'reverse_markdown'
+require 'time'
+require 'json'
+
+filename = ARGV[0]
+
+items = []
+File.open(filename) do |file|
+  items = Nokogiri::XML(file).xpath('//channel//item')
+end
+
+output = []
+
+items.each do |item|
+  name = item.at_xpath('wp:post_name').text.strip
+  title = item.at_xpath('title').text.strip
+  date_str = item.at_xpath('pubDate').text
+  date = DateTime.parse(date_str)
+
+  # Determine the state from categories
+  if item.at_xpath("category[@nicename='open-opportunities']")
+    state = 'open'
+  elsif item.at_xpath("category[@nicename='assigned-opportunities']")
+    state = 'assigned'
+  elsif item.at_xpath("category[@domain='category'][@nicename='closed']")
+    state = 'completed'
+  else
+    next
+  end
+
+  # filename = date.strftime("%Y-%m-%d-%H%M%S-"+name+".markdown")
+  # path = 'app/posts/'+filename
+  content = item.at_xpath('content:encoded').text
+  begin
+    content = ReverseMarkdown.convert(item.at_xpath('content:encoded').text)
+  rescue StandardError => e
+    puts "failed to convert to markdown: #{name} (including raw xml text)"
+    puts "#{e.message}"
+  end
+
+  # Replace relative links, remove clip art, and trim whitespace
+  content.gsub! '(/', '(http://gsablogs.gsa.gov/'
+  content.gsub! '<!--more-->', '\n\n'
+  content.gsub! '&nbsp;', ' '
+  content.gsub! '[![Closed tapas task](http://gsablogs.gsa.gov/dsic/files/2013/04/closed_tapas-.jpg)](http://gsablogs.gsa.gov/dsic/files/2013/04/closed_tapas-.jpg)', ''
+  content.gsub! '[![](http://gsablogs.gsa.gov/dsic/files/2013/04/closed_tapas-.jpg)](http://gsablogs.gsa.gov/dsic/files/2013/04/closed_tapas-.jpg)', ''
+  content.gsub! '[![Tapas plate with the word Closed across.](http://gsablogs.gsa.gov/dsic/files/2013/04/closed_tapas-.jpg)](http://gsablogs.gsa.gov/dsic/files/2013/04/closed_tapas-.jpg)', ''
+  content.gsub! '[![Tapas -- small plates](http://gsablogs.gsa.gov/dsic/files/2013/01/pie2.png)](http://gsablogs.gsa.gov/dsic/files/2013/01/pie2.png)', ''
+  content.gsub! '[![Closed - a photo of a pie with 20% missing](http://gsablogs.gsa.gov/dsic/files/2013/04/closed_pie-1.jpg)](http://gsablogs.gsa.gov/dsic/files/2013/04/closed_pie-1.jpg)', ''
+  content.gsub! '[![](http://gsablogs.gsa.gov/dsic/files/2013/04/closed_hands-1.jpg)](http://gsablogs.gsa.gov/dsic/files/2013/04/closed_hands-1.jpg)', ''
+  content.gsub! '[![closed_hands 1](http://gsablogs.gsa.gov/dsic/files/2013/04/closed_hands-1.jpg)](http://gsablogs.gsa.gov/dsic/files/2013/04/closed_hands-1.jpg)', ''
+  content.strip!
+
+  output << {
+    createdAt: date,
+    name: name,
+    title: title,
+    state: state,
+    description: content
+  }
+end
+
+puts JSON.pretty_generate(output)

--- a/tools/wordpress-import/import-tasks.js
+++ b/tools/wordpress-import/import-tasks.js
@@ -1,0 +1,49 @@
+var Sails = require('sails'),
+    tasks = require('./import.json'),
+    async = require('async');
+
+Sails.lift(function(err, sails) {
+  if (err) throw err;
+
+  // Disable email notifications
+  Notification.create = function(obj, done) { done(); };
+
+  // Override the usual timestamps
+  Task.beforeUpdate = function(obj, done) { done(); };
+
+  // Add additional data to imported tasks
+  tasks.map(function(task) {
+
+    // User should be set to Lisa Nelson's ID
+    task.userId = 1;
+
+    // Set timestamps to creation date
+    switch (task.state) {
+      case 'open':
+        task.publishedAt = task.createdAt;
+        break;
+      case 'assigned':
+        task.publishedAt = task.createdAt;
+        task.assignedAt = task.createdAt;
+        break;
+      case 'completed':
+        task.publishedAt = task.createdAt;
+        task.assignedAt = task.createdAt;
+        task.completedAt = task.createdAt;
+        break;
+    }
+
+    return task;
+  });
+
+  // Create tasks
+  async.eachSeries(tasks, Task.create, done);
+
+  // Log results
+  function done(err) {
+    if (err) return console.error(err);
+    console.log('Added ' + tasks.length + ' tasks.');
+    sails.lower();
+  }
+
+});

--- a/tools/wordpress-import/import.json
+++ b/tools/wordpress-import/import.json
@@ -1,0 +1,1584 @@
+[
+  {
+    "createdAt": "2013-03-15T15:00:46+00:00",
+    "name": "proof-api-documentation-2",
+    "title": "Expand the API material on Howto.gov",
+    "state": "completed",
+    "description": "**Tapas:** Beginning at**  [HowTo.Gov/api](http://www.howto.gov/API),** suggest updates to expand and improve a section of this API guidance. **Duration:**  One to 2 hours. **Deadline:** One week after accepting the task"
+  },
+  {
+    "createdAt": "2013-03-15T16:54:59+00:00",
+    "name": "develop-an-integrated-youtube-widget-for-social-media-registry",
+    "title": "Develop a YouTube widget for the Social Media Registry",
+    "state": "completed",
+    "description": "**Tapas:** Develop a widget that consumes the [Social Media Registry](http://www.usa.gov/About/developer-resources/social-media-registry.shtml) API in order to display the most recent videos from across all government YouTube channels (as listed in the registry). The  [Social Media Registry](http://www.howto.gov/social-media/using-social-media-in-government/social-media-registry) is an official source of information about social media accounts that represent official U.S. federal government agencies, elected officials, or members of the President’s Cabinet.  Check out some  [example applications. ](http://www.usa.gov/About/developer-resources/social-media-registry.shtml#Example_Applications) **Duration** : Two to four hours **Deadline:** Two weeks after accepting the task"
+  },
+  {
+    "createdAt": "2013-03-15T16:58:55+00:00",
+    "name": "develop-an-integrated-twitter-widget-for-social-media-registry",
+    "title": "Develop a Twitter widget for the Social Media Registry",
+    "state": "completed",
+    "description": "**Tapas:** We need your help to develop a widget that contains ALL the Twitter accounts on the Social Media Registry.  The  [Social Media Registry](http://www.howto.gov/social-media/using-social-media-in-government/social-media-registry) is an official source of information about social media accounts that represent official U.S. federal government agencies, elected officials, or members of the President’s Cabinet.  It helps the public determine if an account is managed by an official source or not. A few Twitter accounts and a gallery of existing widgets by agency already exists. Check out some [examples](http://www.howto.gov/social-media/twitter-widgets-gallery).  We need your help to develop a widget that contains ALL the Twitter accounts on the Social Media Registry.  The product will be available to all agencies to display the most recent Tweets from across all government Twitter channels that appear in the Registry. To get started, access the [Registry API](http://www.usa.gov/About/developer-resources/social-media-registry.shtml), volunteer for this tapas, and take the first step in having YOUR widget appear across government. **Duration:** Two to four hours **Deadline:** Two weeks after accepting the task"
+  },
+  {
+    "createdAt": "2013-03-15T17:05:17+00:00",
+    "name": "build-an-integrated-facebook-widget-for-social-media-registry",
+    "title": "Build a Facebook widget for the Social Media Registry",
+    "state": "completed",
+    "description": "**Tapas:** Develop a widget that consumes the [Social Media Registry API](http://www.usa.gov/About/developer-resources/social-media-registry.shtml)  in order to display the most recent facebook activity from across all government Facebook channels (as listed in the registry). The [ Social Media Registry](http://www.howto.gov/social-media/using-social-media-in-government/social-media-registry) is an official source of information about social media accounts that represent official U.S. federal government agencies, elected officials, or members of the President’s Cabinet.  Check out some [example applications. ](http://www.usa.gov/About/developer-resources/social-media-registry.shtml#Example_Applications) **Duration:** Two to four hours **Deadline:** Two weeks after accepting the task"
+  },
+  {
+    "createdAt": "2013-03-15T20:17:02+00:00",
+    "name": "add-an-alt-text-to-image-3",
+    "title": "Add an alt-text to image",
+    "state": "completed",
+    "description": "**Tapas:** Write up alt-text clearly, completely and succinctly describing the image [here](http://www.howto.gov/web-content/digital-metrics/digital-analytics-program). Description will be in plain text (no bold, italics, bullets, links, etc) that will be read via a screen reader. The description can be submitted via email or in a document--so long as it can be cut and pasted into our file. Thanks for helping to make content more accessible! **Duration:** Up to 2 hours **Deadline:** One week after accepting the task"
+  },
+  {
+    "createdAt": "2013-03-15T20:15:28+00:00",
+    "name": "add-an-alt-text-to-image-2",
+    "title": "Add an alt-text to image",
+    "state": "completed",
+    "description": "**Tapas:** Write up alt-text clearly, completely and succinctly describing the image on this [HowTo site](http://www.howto.gov/sites/default/files/common-web-performance-metrics_0.png). This is a bit of a challenge because we are looking not only for a description of the graphic, but more importantly to convey the INFORMATION in the graphic for people who cannot see. Description will be in plain text (no bold, italics, bullets, links, etc) that will be read via a screen reader. The description can be submitted via email or in a document--so long as it can be cut and pasted into our file. Thanks for helping to make content more accessible! **Duration:** Up to two hours **Deadline:** One week after accepting the task"
+  },
+  {
+    "createdAt": "2013-03-15T20:30:34+00:00",
+    "name": "20er",
+    "title": "Open Opportunities (2), an innovative new volunteer program, is open for \"business\"! Want to help us manage it?",
+    "state": "completed",
+    "description": "**20%** - Help coordinate the launch of Open Opportunities. Work with task creators to come up with opportunities, clarify and simplify them , come up with catchy title etc. Institutionalize the concept of chunking tasks to get work done Publish tasks on Open Opportunities page Monitor and answer questions and comments that might come in via email and the blog Communicate with volunteers Suggest ideas to improve the platform or the business process Recognize volunteers via blog, GovD & tweets ( [@Digital\\_Gov](https://twitter.com/Digital_Gov) & [@GovNewMedia](https://twitter.com/GovNewMedia)) Collect analytics, including customer satisfaction data, to help the Center improve the operations of Open Opportunities based on key indicators already identified Start a document with feedback that is received and ideas for the future Participate in weekly coordination meetings. **Duration:** This task will take 20% of a volunteers time over 6 months **Deadline:** TBD after accepting the task"
+  },
+  {
+    "createdAt": "2013-03-15T20:40:23+00:00",
+    "name": "open-opportunities-an-innovative-new-volunteer-program-is-open-for-business-want-to-help-us-manage-it-2",
+    "title": "Open Opportunities (1), an innovative new volunteer program, is open for \"business\"! Want to help us manage it?",
+    "state": "completed",
+    "description": "**20%** : Help coordinate the launch of Open Opportunities by: Drafting promotional messages Reaching out to key stakeholders to let them know about this effort Supporting other communication/promotional efforts Suggesting ideas! **Manage operations** Work with task creators to come up with opportunities Publish tasks on Open Opportunities page Monitor and answer questions and comments that might come in via email and the blog Communicate with volunteers Suggest ideas to improve the platform or the business process Recognize volunteers via blog, GovD & tweets This task will take 20% of the volunteers time over the next 6 months."
+  },
+  {
+    "createdAt": "2013-03-15T21:19:36+00:00",
+    "name": "mobilegov-blogger",
+    "title": "MobileGov guest blogger for \"Trends on Tuesday\"",
+    "state": "completed",
+    "description": "**20%** : Someone to write 1 \"Trends on Tuesday\" blog post per week for the [Mobile Gov Blog](http://howtomobile.apps.gov/). The blog consists of frequent, quick posts on what government is doing in mobile, general mobile news, trends in mobile use, and issues on implementing mobile for the public. Every Tuesday we feature a post on mobile user trends. Trends on Tuesday are kept simple, with a single trend. Posts should be composed in less than an hour to help keep focus on simplicity and speed. To complete your Trends on Tuesday tasks, you will find Pew or other credible, nonpartisan studies of mobile use or choose from a Digital Services Innovation Center list, and write a post about the trend(s). You will also review previous Trends on Tuesday posts for sources and not to repeat previous trends. Each post should include: A link to the source of the trend (article, survey, ettc) A chart, graph or image depicting or representative of the trend A link to resource(s) on the Mobile Gov Wiki A concluding sentence about why this trend is important to government **Duration:**  This task will take the volunteer up to 2 hours per week for 6 months. **Deadline:** TBD after accepting the task."
+  },
+  {
+    "createdAt": "2013-03-15T21:23:39+00:00",
+    "name": "mobile-product-thursday-mobile-gov-blogger",
+    "title": "Mobile Gov guest blogger for \"Mobile Product Thursday\"",
+    "state": "completed",
+    "description": "**20%** : Someone to help improve mobile implementations by writing \"Mobile Product Thursday\" blog post per week for the [Mobile Gov Blog](http://howtomobile.apps.gov/). The blog consists of frequent, quick posts on what government is doing in mobile, general mobile news, trends in mobile use, and issues on implementing mobile for the public. Every Thursday we feature a post on government mobile products. Mobile product blogs are kept simple, with a single trend. Posts should be composed in less than an hour to help keep focus on simplicity and speed. Refer to the [USA.gov Apps Gallery](http://apps.usa.gov/) for ideas, work with Digital Services Innovation Center for features on newer mobile products (app, mobile web, etc.) and write a post about a new mobile product. You will have to check previous posts to make sure your proposed post has recently been blogged about. Each post should include a:\n- Link to the agency who developed the app/site\n- Brief description about what the app does\n- Screen shot of the app\n- Link to the app in USA.gov Apps Gallery or the agency's page advertising the app\n**Duration:** Up to 2 hours per week for 4-6 months **Deadline: ** TBD after accepting the task"
+  },
+  {
+    "createdAt": "2013-03-18T14:38:02+00:00",
+    "name": "easy-source-code-clean-up",
+    "title": "Easy source code clean-up",
+    "state": "completed",
+    "description": "**Tapas:**  Please remove the SPAN tag formatting from the source code on the Mobile Gov Wiki page  [“Android, Open Source, Accessibility Applications”](http://mobilegovwiki.howto.gov/Android%2C+Open+Source%2C+Accessibility+Applications)1. Click the “”Edit”\" button to the right of the page title “”Android, Open Source, Accessibility Applications”\" 2. Click the arrow button on the right-hand side of the “”Save”\" button in the page editing tool bar 3. Click on “”Wikitext Editor.”\" This will switch you from the WYSIWYG editor to the source code 4. Delete all of the <SPAN> tag coding. 5. Save the page See Mobile Gov Wiki’s “ [How to Remove the <SPAN> Tag](http://mobilegovwiki.howto.gov/How+to+Remove+the+%3CSPAN%3E+Tag)” page for an illustrated explanation, and the  [guidelines](http://mobilegovwiki.howto.gov/How+to+participate+in+the+Mobile+Gov+Wiki) on creating and editing pages in the Mobile Gov Wiki for further assistance. Please note that while you do not need to be a member of the Mobile Gov Wiki (tho’ we’d like you to join), you do need a  [Wikispaces](http://www.wikispaces.com/) account (user name, password and email). **Duration:**  20 minutes **Deadline:**  One week after accepting the task"
+  },
+  {
+    "createdAt": "2013-03-18T14:41:48+00:00",
+    "name": "add-quick-links",
+    "title": "Add quick links",
+    "state": "completed",
+    "description": "**Tapas: **This is for the Mobile Gov Wiki page \" [Mobile Frameworks](http://mobilegovwiki.howto.gov/Mobile+Frameworks)).\" Please add links to Wikipedia definitions for the terms libraries and classes found in the first paragraph on this page.\n\nSee the  [guidelines](http://mobilegovwiki.howto.gov/How+to+participate+in+the+Mobile+Gov+Wiki) on creating and editing pages in the Mobile Gov Wiki. Please note that while you do not need to be a member of the Mobile Gov Wiki (tho’ we’d like you to join), you do need a  [Wikispaces](http://www.wikispaces.com/) account (user name, password and email). **Duration: ** This should take 20 minutes. **Deadline: **  Entries are due one week after accepting the task."
+  },
+  {
+    "createdAt": "2013-03-28T20:29:02+00:00",
+    "name": "share-your-agencys-api-insight",
+    "title": "Share an API insight story with others",
+    "state": "completed",
+    "description": "**Tapas**: Help us tell a success story! If your agency has begun generating APIs, you have plenty of insight and experience to share with your fellow agencies. Identify one or two key people in your agency who have a cool story to tell.  Interview them with the following questions:\n1. What is your story?  (a brief description)\n2. What problem are you trying to solve?\n3. How did you solve the problem?\n4. What are the results/impact?\nSend back the completed responses to **digitalgov@gsa.gov**.  You can see other agency case studies [here](http://1.usa.gov/XnVefx). **Duration: ** This task should take 2-4 hours. **Deadline:** Ongoing"
+  },
+  {
+    "createdAt": "2013-03-29T02:43:46+00:00",
+    "name": "help-improve-development-acquisition-for-public-facing-mobile-government-products-and-services-20er",
+    "title": "Help improve development acquisition for public-facing mobile government products and services!",
+    "state": "completed",
+    "description": "**20%:** Agencies need simple solutions for anytime, anywhere mobile product development (apps, mobile web, SMS) and assistance testing these solutions on devices. The Mobile App Development program, part of the Digital Government Strategy, will provide mobile contracting support using the RFP-EZ tool that will allow contracts under the Simple Acquisitions Threshold. This 20%er will help us ensure that the RFP-EZ tool contains sample SOW's for mobile development and app testing, private sector mobile developers and help early adopter agencies use the RFP-EZ tool. Experience with government contracting is a plus. With the Assistance of the Digital Services Innovation Center and the RFP-EZ team, your role will be to: Gather agency SOW's for mobile development Research private sector SOWs, meet with developers to identify requirements/language to better attract innovative mobile developers Create, modify and upload model SOW's, RFP's for mobile development/ app testing into the RFP-EZ tool Identify mobile developer channels to engage and promote government mobile business Identify and shepherd 1-3 agencies through the RFP-EZ procurement process Develop guidance and instructions to help early adopter agencies use RFP-EZ for mobile development and app testing procurement Develop a playbook/FAQs for RPF-EZ for agencies to use for the RFP-EZ process **Duration: ** RFP-EZ Mobile solution will be launched on May 23rd. Looking for a 3 month 20%er. **Deadline: ** TBD after accepting the task."
+  },
+  {
+    "createdAt": "2013-03-29T02:51:50+00:00",
+    "name": "help-develop-a-code-sharing-catalog-to-help-agencies-leverage-mobile-app-development-code-for-anytime-anywhere-government-20er",
+    "title": "Help develop a code sharing catalog to help agencies leverage mobile app development code for anytime, anywhere government!",
+    "state": "completed",
+    "description": "**20%** : Agencies need public and private sector mobile development code to help speed their mobile development efforts. The Mobile App Development program will develop a Github catalog of code that agencies can share, reuse and improve to support mobile applications. Code can support mobile web or native apps. With the assistance of the Digital Services Innovation Center, your role will be to:\n- Identify existing resources for the catalog\n- Host and/or participate in events to create new/enhance existing mobile code for the catalog\n- Create the catalog and develop an operations plan\n- Develop a promotions plan to evangelize the catalog\n**Duration:**  Looking for 4-6 month 20%er. **Deadline: ** May 23rd."
+  },
+  {
+    "createdAt": "2013-03-29T19:05:24+00:00",
+    "name": "add-an-image-alt-text-and-some-stats-to-the-mobile-gov-wiki-tapas",
+    "title": "Add an image, alt-text and some stats to the Mobile Gov Wiki",
+    "state": "completed",
+    "description": "**Tapas** : 1. Add an image of a basic phone with alt-text to the Mobile Gov Wiki page “ [Basic Phones](http://mobilegovwiki.howto.gov/Basic+Phones)”\n\n2. Please add current feature phone market penetration in the US. (What percentage of the population currently still uses a feature phone and the demographics of that population – find some report with stats that are less than one year old) See the  [guidelines](http://mobilegovwiki.howto.gov/How+to+participate+in+the+Mobile+Gov+Wiki) on creating and editing pages in the Mobile Gov Wiki. Please note that while you do not need to be a member of the Mobile Gov Wiki (tho’ we’d like you to join), you do need a  [Wikispaces](http://www.wikispaces.com/) account (user name, password and email). **Duration: ** These two items should take approximately 40 minutes to complete. **Deadline** : Entries are due one week after accepting the task."
+  },
+  {
+    "createdAt": "2013-04-01T18:24:14+00:00",
+    "name": "tapas-trolling-for-treasure",
+    "title": "Trolling for treasure",
+    "state": "completed",
+    "description": "**Tapas:** Spend an hour or so looking for what agencies are doing as part of the [Digital Government Strategy](http://www.whitehouse.gov/sites/default/files/omb/egov/digital-government/digital-government.html). **Instructions** : Browse federal government blogs and agency press releases to find government stories about their digital gov innovations. It could be about releasing an API, a mobile application, their work in opening data, a hackathon or datapalooza, or how their digital work has an impact on their stakeholders. Put the URL for the specific blog entry or press release **_directly in the comments for this post_**. Include your name and agency affiliation (so we can acknowledge your contribution). We'll review and reblog your found treasures.\\n\\n_Story guidelines_: We are most interested in stories about how agencies are serving the public, but won’t totally disregard enterprise successes. We are interested in reposting primarily from government sources–but a really great news story may work in some cases. You can see some examples on the Center blog, like:\n- From the Department of Labor: [Job Search Tools are Going Mobile](http://gsablogs.gsa.gov/dsic/2013/01/18/job-search-tools-are-going-mobile/)\n- From Department of Transportation: [Redesigned www.dot.gov draws a crowd… and goes responsive](http://gsablogs.gsa.gov/dsic/2012/12/17/redesigned-www-dot-gov-draws-a-crowd-and-goes-responsive/)\n- From Department of Energy:  [Department of Energy Implements APIs in the Cloud](http://gsablogs.gsa.gov/dsic/2012/11/25/department-of-energy-implements-apis-in-the-cloud/)\nFor context, this task is important so agencies can see what others are doing to spur ideas and learn from others' experiences. Agencies might find opportunities to partner. It's all part of the formula to help agencies jumpstart their efforts to build a 21st century digital government. **Duration:**  < 1 hour **Deadline:**  This is an ongoing task.  You can volunteer to do it once, or many times."
+  },
+  {
+    "createdAt": "2013-04-01T19:32:49+00:00",
+    "name": "tapas-create-a-linked-in-group",
+    "title": "Create a LinkedIn group",
+    "state": "completed",
+    "description": "**Tapas:** Create a LinkedIn group for the Open Opportunities community. The purpose of the group is to provide federal government innovators with a place to network and share ideas. To start a new group you will need to fill out a profile that includes a description of the group using keywords that will help to generate interest.  You can use language from [this site](http://gsablogs.gsa.gov/dsic/how-it-works/) to create the profile. You must have a [linkedIn account](https://www.linkedin.com/uas/login?session_redirect=http%3A%2F%2Fwww%2Elinkedin%2Ecom%2FpostLogin%3Fsession_rikey%3DoIzhcLIrBWEOoB-gre6KQiZibQt5NAFKULPhDh_5VWFOsu-9TiwdYLp_zK1OrVmGuBaxCnf54nCragb6NepVu1eWLQrM0RJsxLe%26l%3Dhttp%253A%252F%252Fwww%252Elinkedin%252Ecom%252FcreateGroup%253FdisplayCreate%253D%26id%3D0%26b%3Dec0975ba-2fde-4989-afb4-bab1a0d565e6%26h%3D0EZD%26m%3DGET) to perform this task. **Duration:** Up to one hour **Deadline:** One week after accepting"
+  },
+  {
+    "createdAt": "2013-04-01T23:36:30+00:00",
+    "name": "20-percenter-develop-and-manage-the-open-opportunities-linked-in-group",
+    "title": "Develop and manage the Open Opportunities LinkedIn group",
+    "state": "completed",
+    "description": "**20%:**  Grow our newly created Open Opportunities LinkedIn group into a vibrant community. The volunteer will act as leader of the group with the goal of engaging members and is responsible for: • Attracting new users • Keeping current users engaged • Providing valuable feedback to help improve the group • Setting goals and tracking and track how you are doing The manager is expected to connect with and ask questions of the community members, ask questions, invite members to share ideas and ask questions, provide insight and commentary and contribute content that stimulates conversation. This Open Opportunity will allow the volunteer to be creative and experiment to find the best ways to make this a thriving community. **Duration** : 3 to 6 months. Preferred starting date: April 29, 2013. **Deadline** : Ongoing"
+  },
+  {
+    "createdAt": "2013-04-03T17:58:00+00:00",
+    "name": "product-manager-sites-usa-gov",
+    "title": "Product manager sites.usa.gov",
+    "state": "completed",
+    "description": "**Agency Rep**: Seeking  **Product Manager**  to be responsible for both product planning and product marketing for [sites.usa.gov](http://sites.usa.gov/). This includes managing the product throughout the product lifecycle, gathering and prioritizing product and customer requirements, developing the product vision, and working closely with customers and developers to deliver a successful service. It also includes working with the Digital Services Innovation Center team and leadership as well as OMB to ensure that growth and customer satisfaction goals are met. The Product Manager’s job also includes ensuring that the product and marketing efforts support the overall goals of the Federal Digital Strategy and supporting policies.\n\n### Roles and responsibilities\n\n### Product development\n\n- Define the product strategy and roadmap.\n- Deliver marketing requirements and product requirements documents with prioritized features and corresponding justification, to include features, templates, themes.\n- Work closely with technical team to deliver features on 30-day product development cycles\n- Develop systems to solicit and gather client (and potential client) feedback to drive speedy, agile product development\n- Create, test and implement customer experience model with goal of automated, self-service commissioning of sites\n- With technical team and clients develop policy and process to leverage client developed themes, plugins, etc.\nMarketing and Communications\n- Develop and implement customer acquisition plan with Center leadership\n- Develop the core positioning and messaging for the product with Center comms and leadership\n- Develop marketing tools and collateral with Center comms and leadership\n- Communicate updates and improvements to current and future clients.\n- Update sites.usa.gov with information on new features\n- Develop marketing tools and collateral with Center comms and leadership\n- Lead followup and product demos for clients\n- Operations and Service\n- Propose an overall operations model (budget, staffing)  to ensure success\n- Assist in setting of pricing and service options to meet revenue and profitability goals\n- Deliver a monthly/quarterly customer/revenue forecast\nCatalyst for agency adoption of open content management.\n### Commitment\nFull time agency representative for six months."
+  },
+  {
+    "createdAt": "2013-04-16T18:23:41+00:00",
+    "name": "pilot-manager-for-crowd-source-mobile-testing",
+    "title": "Pilot Manager for Crowd-Source Mobile Testing",
+    "state": "completed",
+    "description": "**20%: **Help create quality anytime, anywhere government by developing and managing a crowd-sourced Mobile Product Testing pilot. The Mobile App Development program, part of the [Digital Government Strategy](http://www.whitehouse.gov/sites/default/files/omb/egov/digital-government/digital-government.html \"digital govt strategy\"), includes help for agencies in mobile product testing across a ton of different devices and operating systems. This 20%er will develop a pilot program that will leverage the Open Opportunities program to solicit people (federal employees) to use their own devices to help agencies test mobile products. S/he will help develop the scope of services for the testing pilot, develop and implement a concept of operations that provides \"match-making\" service between testers and agencies and lead the evaluation of the pilot. Your experience with mobile products and project management is a plus. With the Assistance of the Digital Services Innovation Center team, your role will be: **Program Development**\n- Define Mobile Product Testing Open Opportunities Pilot scope of services/operations\n- Develop guidance, instructions and/or play book to help agencies use the Open Opportunities program\n- Develop guidance, instructions and/or play book for application testers\n- Develop an initial SOP including intake of volunteers and creation of a stable of various devices for testing\n- Develop SOP for agencies to access testers\n- Tweak the process based on agency and tester experience\n- Help agencies access the testers\n- Identify and guide agencies to any existing app testing checklists as templates for agency testing protocols\n **Recruiting**\n- Create process for recruiting app testing volunteers via Open Opportunities\n- Promote App Testing pilot to agencies\n**Evaluation**\n- Identify measures (as part of the initial scoping) for evaluation\n- Work with Center staff on Pilot evaluation and reporting."
+  },
+  {
+    "createdAt": "2013-04-16T18:35:26+00:00",
+    "name": "build-out-the-mobile-gov-wiki-functionality-and-usability-testing-resources-page",
+    "title": "Build out the Mobile Gov Wiki Functionality and Usability Testing Resources Page",
+    "state": "completed",
+    "description": "******Tapas:** Please help us add content to the [Mobile Gov Wiki Functionality and Usability Testing Resources page](http://mobilegovwiki.howto.gov/Functionality+and+Usability+Testing+Resources \"mobile gov wiki and resources page\"). We are in the process of building out our resources on mobile app/web testing and have gathered some resources you can use to create this wiki page which we will email to you. The Functionality and Usability Testing Resources page includes both instructions on what to put where (the italicized text which should be deleted once you’ve completed the page) and some general description language in the different sections that act as introductions to the different sections (plain text). Choose this task, and we’ll email you the resource material to get you started. In the meantime, please see the [guidelines on creating and editing pages](http://mobilegovwiki.howto.gov/How+to+participate+in+the+Mobile+Gov+Wiki \"guidelines\") in the Mobile Gov Wiki. Please note that while you do not need to be a member of the Mobile Gov Wiki (tho’ we’d like you to join), you do need a [Wikispaces account](http://www.wikispaces.com/ \"wikispaces\") (user name, password and email)."
+  },
+  {
+    "createdAt": "2013-04-16T19:04:41+00:00",
+    "name": "build-out-the-mobile-gov-wiki-performance-testing-resources-page",
+    "title": "Build out the Mobile Gov Wiki Performance Testing Resources Page",
+    "state": "completed",
+    "description": "**Tapas:** Please help us add content to the [Mobile Gov Wiki Performance Testing Resources](http://mobilegovwiki.howto.gov/Performance+Testing+Resources \"mobilegov wiki\") page. We are in the process of building out our resources on mobile app/web testing and have gathered some resources you can use to create this wiki page which we will email to you. The Performance Testing Resources page includes both instructions on what to put where (the italicized text which should be deleted once you’ve completed the page) and some general description language in the different sections that act as introductions to the different sections (plain text). Choose this task, and we’ll email you the resource material to get you started. In the meantime, please see [the guidelines on creating and editing pages](http://mobilegovwiki.howto.gov/How+to+participate+in+the+Mobile+Gov+Wiki \"guidelines\") in the Mobile Gov Wiki. Please note that while you do not need to be a member of the Mobile Gov Wiki (tho’ we’d like you to join), you do need a [Wikispaces account](http://www.wikispaces.com \"wikispaces\") (user name, password and email)."
+  },
+  {
+    "createdAt": "2013-04-16T19:08:16+00:00",
+    "name": "build-out-the-mobile-gov-wiki-accessibility-testing-resources-page",
+    "title": "Build out the Mobile Gov Wiki Accessibility Testing Resources Page",
+    "state": "completed",
+    "description": "**Tapas:** Please help us add content to the [Mobile Gov Wiki Accessibility Testing Resources](http://mobilegovwiki.howto.gov/Accessibility+Testing+Resources \"mobile gov testing\") page. We are in the process of building out our resources on mobile app/web testing and have gathered some resources you can use to create this wiki page which we will email to you. The Accessibility Testing Resources page includes both instructions on what to put where (the italicized text which should be deleted once you’ve completed the page) and some general description language in the different sections that act as introductions to the different sections (plain text). Choose this task, and we’ll email you the resource material to get you started. In the meantime, please see [the guidelines on creating and editing pages](http://mobilegovwiki.howto.gov/How+to+participate+in+the+Mobile+Gov+Wiki \"guidelines\") in the Mobile Gov Wiki. Please note that while you do not need to be a member of the Mobile Gov Wiki (tho’ we’d like you to join), you do need a [Wikispaces account](http://www.wikispaces.com \"wikispaces\") (user name, password and email)."
+  },
+  {
+    "createdAt": "2013-04-16T19:11:29+00:00",
+    "name": "build-out-the-mobile-gov-wiki-security-and-privacy-testing-resources-page",
+    "title": "Build out the Mobile Gov Wiki Security and Privacy Testing Resources Page",
+    "state": "completed",
+    "description": "**Tapas:** Please help us add content to the [Mobile Gov Wiki Security and Privacy Testing Resources](http://mobilegovwiki.howto.gov/Security+and+Privacy+Testing+Resources \"mobile gov wiki page\") page. We are in the process of building out our resources on mobile app/web testing and have gathered some resources you can use to create this wiki page which we will email to you. The Security and Privacy Testing Resources page includes both instructions on what to put where (the italicized text which should be deleted once you’ve completed the page) and some general description language in the different sections that act as introductions to the different sections (plain text). Choose this task, and we’ll email you the resource material to get you started. In the meantime, please see [the guidelines on creating and editing pages](http://mobilegovwiki.howto.gov/How+to+participate+in+the+Mobile+Gov+Wiki \"guidelines\") in the Mobile Gov Wiki. Please note that while you do not need to be a member of the Mobile Gov Wiki (tho’ we’d like you to join), you do need a [Wikispaces account](http://www.wikispaces.com \"wikispaces\") (user name, password and email)."
+  },
+  {
+    "createdAt": "2013-04-22T20:30:16+00:00",
+    "name": "lead-for-training-and-support-for-the-digital-analytics-program-dap",
+    "title": "Lead for Training and Support for the Digital Analytics Program (DAP).",
+    "state": "completed",
+    "description": "**20%: **The Lead would be part of the implementation and support team for the Digital Analytics Program (DAP). This initiative is a key component of the Federal CIO’s Digital Strategy with the goal to improve the customer experience by gathering common performance metrics across federal websites and analyze this data to manage our digital services more efficiently. The detailee would collaborate with senior IT and digital strategy managers from every cabinet department, and with program staff at GSA, the Office of Management and Budget, and the White House Office of Digital Strategy.\\n\\n1.  Develop a training series and resources to help agencies gain value for their agency from the DAP.\n- Work with DigitalGov University to execute these events. Series to includes Getting Started with Google Analytics (part a: with DAP / part b: with your own account)\n- The Fundamentals: Reports, Dashboards, Filters & Segments\n- Google Analytics Reports Demystified\n2.  Develop supporting resources, including:\n- “Tuesday Tips” blog series\n- Short How-To type videos\n- Case studies good and bad\n- Create DAP relevant content  for Digital Services Innovation Center and/or HowTo.gov websites.\n- Assist with inquiries and help desk issues triage via the DAP email account\n\n**Duration:**  6 months with a start date of May 1.\n\n**Deadline:** Ongoing"
+  },
+  {
+    "createdAt": "2013-04-23T14:42:42+00:00",
+    "name": "design-a-template-in-govdelivery-for-the-digital-digest",
+    "title": "Design a Template in GovDelivery for the Digital Digest",
+    "state": "completed",
+    "description": "**Tapas:** The Digital Digest is a weekly email recap of highlights from the [DigitaGov Blog](http://blog.howto.gov/) and other hot items that have emerged relating to the use of digital tools. The goal is to expand our customer base capturing more people and sending  them to our services. The ideal volunteer is someone who can create a template in Govdelivery that will give a fresh new modern look to the the Digital Digest . The Template should provide **scannable content** that will function as a gateway to the blog itself and other services. The individual will collaborate with Digital Services team to conceptualize the template and then build. The template will provide areas for:\n- Blog post summaries and links\n- Photos\n- Training and other events\n- Important Links (to the Blog, Twitter, Facebook)\n_If you do not currently have access to GovDelivery we can grant you access to work through our account._Examples: [http://www.a2gov.org/government/city\\_administration/communicationsoffice/Pages/A2CityNewsResidentNewsletter.aspx](http://www.a2gov.org/government/city_administration/communicationsoffice/Pages/A2CityNewsResidentNewsletter.aspx) [http://content.govdelivery.com/bulletins/gd/NCRALEIGH-540825](http://content.govdelivery.com/bulletins/gd/NCRALEIGH-540825) [http://content.govdelivery.com/bulletins/gd/MPLS-700cc4](http://content.govdelivery.com/bulletins/gd/MPLS-700cc4) **Duration:** 6-8 hours **Deadline** : May 24, 2013 (Some flexibility in date)"
+  },
+  {
+    "createdAt": "2013-04-30T15:09:59+00:00",
+    "name": "provide-alt-text-language-for-the-application-programming-interfaces-apis-page-on-the-mobile-gov-wiki",
+    "title": "Provide alt-text language for the Application Programming Interfaces (APIs) page on the Mobile Gov Wiki",
+    "state": "completed",
+    "description": "**Tapas:** Write up an alt-text description that completely and succinctly describes the image and includes the data shown in the graph on the following page in the Mobile Gov Wiki: [Application Programming Interfaces](http://mobilegovwiki.howto.gov/Application+Programming+Interfaces+%28APIs%29) (APIs). Description will be in plain text (no bold, italics, bullets, links, etc) that will be read via a screen reader. The description can be submitted via email or in a document–so long as it can be cut and pasted into our file. Thanks for helping to make content more accessible! **Duration:** A few minutes to an hour. **Deadline:** One week after the task has been assigned."
+  },
+  {
+    "createdAt": "2013-04-30T15:10:24+00:00",
+    "name": "provide-descriptive-captions-for-the-answers-respuestas-on-ed-gov-page-on-the-mobile-gov-wiki",
+    "title": "Provide descriptive captions for the  Answers-Respuestas on ED.gov page on the Mobile Gov Wiki",
+    "state": "completed",
+    "description": "**Tapas:** Write up descriptive captions for the two images on the following page in the Mobile Gov Wiki: [Answers-Respuestas on ED.gov](http://gsablogs.gsa.gov//mobilegovwiki.howto.gov/Answers-Respuestas+on+ED.gov).\\n\\nSee the [guidelines](http://mobilegovwiki.howto.gov/How+to+participate+in+the+Mobile+Gov+Wiki) on creating and editing pages in the Mobile Gov Wiki. Please note that while you do not need to be a member of the Mobile Gov Wiki (tho’ we’d like you to join), you do need a [Wikispaces account](http://www.wikispaces.com/) (user name, password and email). **Duration:** A few minutes to an hour **Deadline:** One week after the task is assigned"
+  },
+  {
+    "createdAt": "2013-04-30T15:09:29+00:00",
+    "name": "provide-a-descriptive-caption-for-the-apps-usa-gov-page-on-the-mobile-gov-wiki",
+    "title": "Provide a descriptive caption for the Apps.usa.gov  page on the Mobile Gov Wiki",
+    "state": "completed",
+    "description": "**Tapas**: Write up a descriptive caption to the image on the following page in the Mobile Gov Wiki: [Apps.usa.gov](http://mobilegovwiki.howto.gov/Apps.usa.gov). See the [guidelines](http://mobilegovwiki.howto.gov/How+to+participate+in+the+Mobile+Gov+Wiki)  on creating and editing pages in the Mobile Gov Wiki. Please note that while you do not need to be a member of the Mobile Gov Wiki (tho’ we’d like you to join), you do need a [Wikispaces](http://www.wikispaces.com/) account (user name, password and email). **Duration** : A few minutes to an hour. **Deadlines:** One week after task is assigned"
+  },
+  {
+    "createdAt": "2013-04-30T15:06:27+00:00",
+    "name": "edit-the-mobile-gov-wiki-guidelines-for-testing-page",
+    "title": "Edit the Mobile Gov Wiki Guidelines for Testing Page",
+    "state": "completed",
+    "description": "Please edit the [Guidelines for Testing](http://mobilegovwiki.howto.gov/Guidelines+to+Testing) Mobile Gov Wiki page to make it conform with newly created mobile testing resources pages. For this task, complete the following: 1) Revise content in the “Testing should focus on the following” section to include links to the following wiki pages (and link back to this page from them): [Accessibility Testing Resources](http://mobilegovwiki.howto.gov/Accessibility+Testing+Resources),  [Functionality and Usability Testing Resources](http://mobilegovwiki.howto.gov/Functionality+and+Usability+Testing+Resources),  [Performance Testing Resources](http://mobilegovwiki.howto.gov/Performance+Testing+Resources), [Security and Privacy Testing Resources](http://mobilegovwiki.howto.gov/Security+and+Privacy+Testing+Resources). 2) Create a section on testing scripts that will provide links to sample testing scripts that reside in the Mobile Code Sharing Catalog on GitHub. The links will be provided to you once the assignment has been accepted. 3) Create a table of contents for the page after you have completed the first two tasks. See [the guidelines](http://http://mobilegovwiki.howto.gov/How+to+participate+in+the+Mobile+Gov+Wiki) on creating and editing pages in the Mobile Gov Wiki. Please note that while you do not need to be a member of the Mobile Gov Wiki (tho’ we’d like you to join), you do need a [Wikispaces](http://www.wikispaces.com/) account (user name, password and email). **Duration: ** Two to 4 hours **Deadline:** One week after the task has been assigned"
+  },
+  {
+    "createdAt": "2013-04-30T15:08:07+00:00",
+    "name": "develop-a-formula-to-link-a-few-cells-on-a-google-excel-spreadsheet",
+    "title": "Develop a formula to link a few cells on a Google Excel Spreadsheet",
+    "state": "completed",
+    "description": "**Tapas:** Develop a Google excel spreadsheet formula or function that allows the text in 3 columns in one sheet to automatically show up on another sheet within the same spreadsheet. **Duration** : up to 2 hours **Deadline** : One week after the task is assigned"
+  },
+  {
+    "createdAt": "2013-04-30T15:07:15+00:00",
+    "name": "identify-digital-gov-events-during-june",
+    "title": "Identify Digital Gov Events During June",
+    "state": "completed",
+    "description": "**Tapas**: We need your help identifying events in DC in June.  We want a list of FREE, LOCAL, OPEN to everyone events and meet-ups on topics related to Digital Government. Tell us, in whatever format you chose: 1. Name of event 2. Date of event 3. Address/location 4. Sponsor 5. Link to event You’ll help us make sure we don’t miss anything! **Duration: ** Up to 2 hours **Deadline: ** One week after the task is assigned"
+  },
+  {
+    "createdAt": "2013-05-03T20:19:08+00:00",
+    "name": "build-out-the-mobile-gov-wiki-accessibility-testing-resources-page-2",
+    "title": "Build out the Mobile Gov Wiki Accessibility Testing Resources Page",
+    "state": "completed",
+    "description": "**Tapas:** Please help us add content to the  [Mobile Gov Wiki Accessibility Testing Resources page](http://mobilegovwiki.howto.gov/Accessibility+Testing+Resources \"mobile gov wiki and resources page\"). We are in the process of building out our resources on mobile app/web testing and have gathered some resources you can use to create this wiki page which we will email to you. The Accessibility Testing Resources page includes both instructions on what to put where (the italicized text which should be deleted once you’ve completed the page) and some general description language in the different sections that act as introductions to the different sections (plain text). Choose this task, and we’ll email you the resource material to get you started. In the meantime, please see the  [guidelines on creating and editing pages](http://mobilegovwiki.howto.gov/How+to+participate+in+the+Mobile+Gov+Wiki \"guidelines\") in the Mobile Gov Wiki. Please note that while you do not need to be a member of the Mobile Gov Wiki (tho’ we’d like you to join), you do need a  [Wikispaces account](http://www.wikispaces.com/ \"wikispaces\") (user name, password and email)."
+  },
+  {
+    "createdAt": "2013-05-07T15:23:44+00:00",
+    "name": "help-us-tell-the-story-about-a-nih-rockstar-who-is-creating-modular-on-the-go-content",
+    "title": "Help us tell the story about a NIH rockstar who is creating modular on-the-go content",
+    "state": "completed",
+    "description": "**Tapas:** This is a great opportunity for a Clark Kent or Lois Lane wannabe. Are you an \"intrepid reporter\" who wants to learn about structured content? If so, then this task is for you!\\n\\nStructured content refers to the concept of organizing and treating digital content like data. It’s a way of publishing content as modular, discrete pieces of information that are tagged with machine-readable descriptions. Structured content has the potential to transform how people find, understand, share, and use government information, and it’s key to helping the public access government information anytime, anywhere, on any device. We've identified someone at NIH and we need help to interview them, capture their stories, and publish them on HowTo.gov. Below are brief questions for you to ask. Feel free to add your own too!\n1. What was the problem that you were trying to solve?\n2. What solution did you come up with?\n3. What were the results?\n4. Why is this important?\nWe’ll give you the contact info for the person you're to interview. Your mission (if you chose to accept it) will be to conduct a brief interview (phone or in-person - your choice), capture the answers to the questions, type them up, and send them to the HowTo.gov team. The HowTo team will turn your submission into a story/case study and publish on HowTo.gov. **Deadline:**  One week after interview held. **Duration** : Up to 2 hours"
+  },
+  {
+    "createdAt": "2013-05-07T15:22:39+00:00",
+    "name": "data-gov-scavenger-hunt",
+    "title": "Tag Data.gov’s Tools",
+    "state": "completed",
+    "description": "**Tapas**: Tag only 20 [Data.gov Tools](https://explore.data.gov/catalog/tools) using 4 predetermined categories. We’ll provide the spreadsheet and a few instructions. (It’s a very simple AND easy process!).\n\nNo tech experience necessary! We just need someone with an eye for detail!\n\n**Duration:** Up to 1 hour\n\n**Deadline:** This is an ongoing task.  You can volunteer to do it once, or many times.\n\n**Context: **   [Data.gov](http://data.gov) is the nation’s one-stop shop for Federal government data. We have access to data from 172 agencies, along with apps and tools, gadgets and widgets.\n\nOver the past four years, this catalog has become a catch-all and we’re not really sure what’s in it. We know we’ve got widgets, gadgets, data extraction tools,and RSS feeds.  And maybe you’ll find something more!\n\nWhen we’ve got everything listed and categorized, we’ll know better how to catalog them — or if they’re still useful."
+  },
+  {
+    "createdAt": "2013-05-07T15:23:21+00:00",
+    "name": "source-code-clean-up-on-the-mobile-gov-wiki-performance-testing-resources-page",
+    "title": "Source Code Clean Up on the Mobile Gov Wiki Performance Testing Resources page",
+    "state": "completed",
+    "description": "**Tapas**: Please remove the SPAN tag formatting from the source code on the [Mobile Gov Wiki page Performance Testing Resources](http://mobilegovwiki.howto.gov/Performance+Testing+Resources)1. Click the “”Edit”” button to the right of the page title “Performance Testing Resources\" 2. Click the arrow button on the right-hand side of the “”Save”” button in the page editing tool bar 3. Click on “”Wikitext Editor.”” This will switch you from the WYSIWYG editor to the source code 4. Delete all of the <SPAN> tag coding. 5. Save the page See Mobile Gov Wiki’s “ [How to Remove the <SPAN> Tag](http://mobilegovwiki.howto.gov/How+to+Remove+the+%3CSPAN%3E+Tag)\" page for an illustrated explanation, and the [guidelines](http://mobilegovwiki.howto.gov/How+to+participate+in+the+Mobile+Gov+Wiki)  on creating and editing pages in the Mobile Gov Wiki for further assistance. Please note that while you do not need to be a member of the Mobile Gov Wiki (tho’ we’d like you to join), you do need a [Wikispaces](http://www.wikispaces.com/)  account (user name, password and email). **Duration** : A few minutes to 1 hour. **Deadline** : One week after task is assigned"
+  },
+  {
+    "createdAt": "2013-05-07T15:23:02+00:00",
+    "name": "source-code-clean-up-on-the-mobile-gov-wiki-functionality-and-usability-testing-resources-page",
+    "title": "Source Code Clean Up on the Mobile Gov Wiki Functionality and Usability Testing Resources page",
+    "state": "completed",
+    "description": "**Tapas:** Please remove the SPAN tag formatting from the source code on the [Mobile Gov Wiki page Functionality and Usability Testing Resources](http://mobilegovwiki.howto.gov/Functionality+and+Usability+Testing+Resources). 1. Click the “”Edit”” button to the right of the page title “Functionality and Usability Testing Resources\"\" 2. Click the arrow button on the right-hand side of the “”Save”” button in the page editing tool bar 3. Click on “”Wikitext Editor.”” This will switch you from the WYSIWYG editor to the source code 4. Delete all of the <SPAN> tag coding. 5. Save the page See Mobile Gov Wiki’s “ [How to Remove the <SPAN> Tag](http://mobilegovwiki.howto.gov/How+to+Remove+the+%3CSPAN%3E+Tag)\"\"page for an illustrated explanation, and the  [guidelines ](http://mobilegovwiki.howto.gov/How+to+participate+in+the+Mobile+Gov+Wiki) on creating and editing pages in the Mobile Gov Wiki for further assistance. Please note that while you do not need to be a member of the Mobile Gov Wiki (tho’ we’d like you to join), you do need a  [Wikispaces](http://www.wikispaces.com) account (user name, password and email). **Duration:** A few minutes to and hour. **Deadline:** One week after the task is assigned."
+  },
+  {
+    "createdAt": "2013-05-07T15:22:19+00:00",
+    "name": "play-data-baseball",
+    "title": "Play Data Baseball",
+    "state": "completed",
+    "description": "**Tapas**: Identify 5 companies or organizations who are using open government data.  We need the URL directly linking to show how the data is being used, the company or organization name, a point of contact, and the specific government dataset being used.  For example, [Bright Scope](http://www.brightscope.com/) uses financial data from the government to help rate and rank the retirement account recommendations they give to companies that use their service.  Get started by checking out [alpha.data.gov](http://alpha.data.gov/) for some ideas of what's already been collected.\\n\\n **Context:** The Open Data Initiative from the White House Office of Science and Technology Policy (OSTP) is looking for businesses and researchers that are using government open data.  The best examples will be freatured on [Alpha.Data.gov](http://alpha.data.gov/), and can also be used in presentations, at events, and in other ways.  Join Data.gov in creating a winning team of hits, home runs, and pop-ups (we can even learn from strike outs) in the field of open data innovation. **Duration** : Up to 2 hours **Deadline** : Ongoing"
+  },
+  {
+    "createdAt": "2013-05-07T15:21:59+00:00",
+    "name": "adopt-an-open-data-state",
+    "title": "Adopt an Open Data State",
+    "state": "completed",
+    "description": "**Tapas:** Help Data.gov find websites that are sharing government open data for cities and counties for every state.  We have some sites, but need your help to uncover more!  Pick a state, county, and/or city that is not included [on this list](http://www.data.gov/opendatasites).\n\n\\n\\nFind the aggregate data sharing sites for state, cities, and counties indicating your findings [on this doc](https://docs.google.com/spreadsheet/ccc?key=0AoHbodHAIXgLdFhQZUdzNExCVU5ZNzR0OGN6ZTdNNXc#gid=0) to include:\n\n- URL\n- Site manager/owner contact information\n- Format (XML or other) of how the raw data is offered\n- Any other notes of importance\n\nWhat you find will be included in [Open Data Sites](http://www.data.gov/opendatasites) and you earn a badge and help to build the map!\n\nHere are some examples of cities, and counties already sharing data:   [San Francisco](https://data.sfgov.org/), [Palo Alto](http://paloalto.opendata.junar.com/), [Santa Cruz](http://data.cityofsantacruz.com/),   [San Francisco County](https://data.sfgov.org/), and [Albuquerque](http://www.cabq.gov/abq-data/).\n\n**Duration** :  1-2 hours\n\n**Deadline:  ** Ongoing"
+  },
+  {
+    "createdAt": "2013-05-13T20:02:34+00:00",
+    "name": "source-code-clean-up-on-the-mobile-gov-wiki-security-and-privacy-testing-resources-page",
+    "title": "Source Code Clean Up on the Mobile Gov Wiki Security and Privacy Testing Resources page",
+    "state": "completed",
+    "description": "**Tapas**: Please remove the SPAN tag formatting from the source code on the [Mobile Gov Wiki page Security and Privacy Testing Resources](http://mobilegovwiki.howto.gov/Security+and+Privacy+Testing+Resources).\n\n\\n\\n\n\n1. Click the “”Edit”” button to the right of the page title “PUT PAGE TITLE HERE\"\n\n2. Click the arrow button on the right-hand side of the “”Save”” button in the page editing tool bar\n\n3. Click on “”Wikitext Editor.”” This will switch you from the WYSIWYG editor to the source code\n\n4. Delete all of the <SPAN> tag coding.\n\n5. Save the page\n\nSee Mobile Gov Wiki’s “ [How to Remove the <SPAN> Tag](http://mobilegovwiki.howto.gov/How+to+Remove+the+%3CSPAN%3E+Tag)\"page for an illustrated explanation, and the [guidelines](http://mobilegovwiki.howto.gov/How+to+participate+in+the+Mobile+Gov+Wik) on creating and editing pages in the Mobile Gov Wiki for further assistance.\n\nPlease note that while you do not need to be a member of the Mobile Gov Wiki (tho’ we’d like you to join), you do need a [Wikispaces](http://www.wikispaces.com/) account (user name, password and email).\n\n  **Duration** : A few minutes to 1 hour.\n\n**Deadline** : One week after task is assigned"
+  },
+  {
+    "createdAt": "2013-05-13T20:01:43+00:00",
+    "name": "source-code-clean-up-on-the-mobile-gov-wiki-accessibility-testing-resources-page",
+    "title": "Source Code Clean Up on the Mobile Gov Wiki Accessibility Testing Resources page",
+    "state": "completed",
+    "description": "**Tapas:** Please remove the SPAN tag formatting from the source code on the [Mobile Gov Wiki page Accessibility Testing Resources](http://mobilegovwiki.howto.gov/Accessibility+Testing+Resources).\n\n\\n\\n\n\n1. Click the “”Edit”” button to the right of the page title “PUT PAGE TITLE HERE\"\n\n2. Click the arrow button on the right-hand side of the “”Save”” button in the page editing tool bar\n\n3. Click on “”Wikitext Editor.”” This will switch you from the WYSIWYG editor to the source code\n\n4. Delete all of the <SPAN> tag coding.\n\n5. Save the page\n\nSee Mobile Gov Wiki’s “ [How to Remove the <SPAN> Tag](http://mobilegovwiki.howto.gov/How+to+Remove+the+%3CSPAN%3E+Tag)\" page for an illustrated explanation, and the [guidelines](http://mobilegovwiki.howto.gov/How+to+participate+in+the+Mobile+Gov+Wiki) on creating and editing pages in the Mobile Gov Wiki for further assistance.\n\nPlease note that while you do not need to be a member of the Mobile Gov Wiki (tho’ we’d like you to join), you do need a [Wikispaces](http://www.wikispaces.com/) account (user name, password and email).\n\n  **Duration** : A few minutes to 1 hour.\n\n**Deadline** : One week after task is assigned"
+  },
+  {
+    "createdAt": "2013-05-13T20:00:54+00:00",
+    "name": "add-links-to-the-mobile-gov-wiki-user-experience-page",
+    "title": "Add Links to the Mobile Gov Wiki User Experience Page",
+    "state": "completed",
+    "description": "**Tapas**: Please edit the [User Experience page tools section](http://mobilegovwiki.howto.gov/User+Experience#x-Mobile%20User%20Experience%20Tools) of the Mobile Gov Wiki by adding links to specific UX tools which we will provide upon acceptance of the task.\n\nSee the [guidelines](http://mobilegovwiki.howto.gov/How+to+participate+in+the+Mobile+Gov+Wiki) creating and editing pages in the Mobile Gov Wiki.\n\nPlease note that while you do not need to be a member of the Mobile Gov Wiki (tho’ we’d like you to join), you do need a [Wikispaces account](http://www.wikispaces.com/) (user name, password and email).\n\n  **Duration** : A few minutes to 1 hour.\n\n**Deadline** : One week after task is assigned"
+  },
+  {
+    "createdAt": "2013-05-13T23:23:12+00:00",
+    "name": "identify-digital-gov-conference-speakers-and-presentations",
+    "title": "Identify Digital Gov conference speakers and presentations",
+    "state": "completed",
+    "description": "******Tapas:**  Conduct a search of digital gov related presentations and speakers from the first quarter of this year (2013).\n\n**Instructions** : Browse the web to find conferences related to digital gov held in Jan-Mar. Topics may include but not limited to APIs, mobile, opening data, use of social media or analytics - and how their digital work has an impact on their stakeholders.\\n\\n **Deliverable** : In the text of an email, a Word or Excel doc, or a Google Doc include:\n- Name of event\n- \n\nName of the session/topic\n\n- \n\nSpeaker(s)\n\n- \n\nLink to event site\n\n- \n\nLink to event presentation or video of presentation, if available\n\n**Context:** We will use this resource to identify digital innovators and their innovations that might otherwise fly under the radar. This task is important so agencies can see what others are doing to help spur ideas and learn from others' experiences. Some of these experiences might become best practices, blog posts or a followup webinar. It’s all part of the formula to help agencies jumpstart their efforts to build a 21st century digital government. You’ll help us make sure we don’t miss anything! Duration:  4 hours Deadline: Two weeks after the task is assigned"
+  },
+  {
+    "createdAt": "2013-05-14T13:56:43+00:00",
+    "name": "excel-at-excel-some-miscellaneous-excel-tasks",
+    "title": "Excel at Excel: Some Miscellaneous Excel Tasks",
+    "state": "completed",
+    "description": "**Tapas:** We need a volunteer who has lots of experience using Excel (and loves it!). **Instructions:** The volunteer will help us lock a couple of formulas in an Excel sheet, make a few tweaks to the worksheet and provide us with some general feedback. We want to make better use of this document to track metrics for our program. **Duration:**  4 to 8 hours **Deadline:** One week after accepting the task"
+  },
+  {
+    "createdAt": "2013-05-20T17:50:51+00:00",
+    "name": "replace-image-on-the-apps-usa-gov-mobile-gov-wiki-page",
+    "title": "Replace image on the Apps.USA.gov Mobile Gov Wiki page",
+    "state": "completed",
+    "description": "Tapas: Please update the Apps Gallery ( [http://apps.usa.gov/](http://apps.usa.gov/)) image on the page (the Apps Gallery has recently redesigned their site and the current image is now out of date) and provide a caption for it.\n\n\\n\\n\n\nSee the guidelines [[http://mobilegovwiki.howto.gov/How+to+participate+in+the+Mobile+Gov+Wiki](http://mobilegovwiki.howto.gov/How+to+participate+in+the+Mobile+Gov+Wiki)] on creating and editing pages in the Mobile Gov Wiki.\n\nPlease note that while you do not need to be a member of the Mobile Gov Wiki (tho’ we’d like you to join), you do need a Wikispaces account [[http://www.wikispaces.com/](http://www.wikispaces.com/)] (user name, password and email).\n\n**Duration:** This task should take no more than 1 hour.\n\n**Deadline:**  Task should to be completed one week after acceptance."
+  },
+  {
+    "createdAt": "2013-05-20T17:55:45+00:00",
+    "name": "easy-source-code-clean-up-for-the-user-experience-mobile-gov-wiki-page",
+    "title": "Easy Source Code Clean Up for the User Experience Mobile Gov Wiki Page",
+    "state": "completed",
+    "description": "**Tapas: **Please remove the SPAN tag formatting from the source code on the User Experience Mobile Gov Wiki page [[http://mobilegovwiki.howto.gov/User+Experience](http://mobilegovwiki.howto.gov/User+Experience)]\n\n\\n\\n\n\n1. Click the “”Edit”” button to the right of the page title “User Experience\"\n\n2. Click the arrow button on the right-hand side of the “”Save”” button in the page editing tool bar\n\n3. Click on “”Wikitext Editor.”” This will switch you from the WYSIWYG editor to the source code\n\n4. Delete all of the <SPAN> tag coding.\n\n5. Save the page\n\nSee Mobile Gov Wiki’s “ [How to Remove the <SPAN> Tag](http://mobilegovwiki.howto.gov/How+to+Remove+the+%3CSPAN%3E+Tag)\"[[http://mobilegovwiki.howto.gov/How+to+Remove+the+%3CSPAN%3E+Tag](http://mobilegovwiki.howto.gov/How+to+Remove+the+%3CSPAN%3E+Tag)] page for an illustrated explanation, and the [guidelines](http://mobilegovwiki.howto.gov/How+to+participate+in+the+Mobile+Gov+Wiki) [[http://mobilegovwiki.howto.gov/How+to+participate+in+the+Mobile+Gov+Wiki](http://mobilegovwiki.howto.gov/How+to+participate+in+the+Mobile+Gov+Wiki)] on creating and editing pages in the Mobile Gov Wiki for further assistance.\n\nPlease note that while you do not need to be a member of the Mobile Gov Wiki (tho’ we’d like you to join), you do need a [Wikispaces](http://www.wikispaces.com/) [[http://www.wikispaces.com/](http://www.wikispaces.com/)] account (user name, password and email).\n\n**Duration:** This task should take no more than 1 hour.\n\n**Deadline:**  Task should to be completed one week after acceptance."
+  },
+  {
+    "createdAt": "2013-05-20T18:00:27+00:00",
+    "name": "design-badges-for-open-opps-wall-of-fame",
+    "title": "Design badges for Open Opps Wall of Fame",
+    "state": "completed",
+    "description": "**Tapas: **Imagine having your designs highlighted to all of government on this blog.  We need a set of three online badges to recognize our Open Opportunity volunteers: tapas, 20%, and agency reps.  Please send us a set of three designs adhering to a look and feel similar to the already existing Wall of Fame logo ( [http://gsablogs.gsa.gov/dsic/category/wall-of-fame](http://gsablogs.gsa.gov/dsic/category/wall-of-fame/)).\\n\\nTo keep in mind: 1. Tapas tasks are short and can be completed on average in a few hours. 2. 20%-ers work on a specific project for several weeks or months, spending time at both their home agency and about 20% of their time working with the host agency. 3. Agency reps commit to 3-6 month details at a host agency. Original artwork is encouraged.  Remember, this is a US Government site and we need to make sure all designs can legally be displayed on this site. Submit your designs and be the first to earn YOUR new badge! **Deadline:** 2 weeks after accepting the task **Duration:** 4-8 hours"
+  },
+  {
+    "createdAt": "2013-06-04T11:56:09+00:00",
+    "name": "design-an-email-newsletter-template",
+    "title": "Design an Email Newsletter Template",
+    "state": "completed",
+    "description": "******Tapas**: We need someone who can design an email newsletter template for our weekly Taste of Tapas newsletter. The ideal volunteer is someone who can create a template in GovDelivery that will give a fresh new modern look to the newsletter. _(If you do not currently have access to GovDelivery we can grant you access to work through our account.)_\\n\\nThe template should provide scannable, eye-catching content that will drive potential volunteers to check out the new tasks available each week. The Taste of Tapas newsletter is a weekly email highlighting new volunteer opportunities through the Open Opportunities program. The goal is drive potential volunteers to check out the new tasks available each week. Our ideal volunteer will collaborate with the Open Opportunities team to conceptualize the template and then build. The template will provide areas for:\n- New volunteer opportunities\n- News updates\n- Highlighting exceptional volunteers\n- Important Links (to the Blog, Twitter, Facebook, etc.)\n**Examples:** [http://content.govdelivery.com/bulletins/gd/NCRALEIGH-540825](http://content.govdelivery.com/bulletins/gd/NCRALEIGH-540825) [http://content.govdelivery.com/bulletins/gd/MPLS-700cc4](http://content.govdelivery.com/bulletins/gd/MPLS-700cc4) **Duration:** 6-8 hours **Deadline:** June 18, 2013 (Some flexibility in date)"
+  },
+  {
+    "createdAt": "2013-06-04T11:55:49+00:00",
+    "name": "cut-and-edit-video",
+    "title": "Cut and Edit Video",
+    "state": "completed",
+    "description": "**Tapas:** Break down a 60 min DigitalGov University webinar recording, currently in a wmv format, into 3 separate and discrete videos. The videos should be able to stand alone and should be delivered in .wmv or .mp4 format with standard intros and outros (which the team will provide). The DGU team will provide direction as to where to cut/edit the video.\\n\\n **Context:** DigitalGov University is the federal government's training program for digital media and citizen engagement and is supports the digital strategy by hosting all the training associated with meeting the milestones. **Duration:** 2-4 hours **Deadline:** 2 weeks from the acceptance of the tapas."
+  },
+  {
+    "createdAt": "2013-06-04T11:55:26+00:00",
+    "name": "edit-video-transcript-for-accuracy",
+    "title": "Edit Video Transcript for Accuracy",
+    "state": "completed",
+    "description": "**Tapas:** Review and edit a 60 min DigitalGov University webinar transcript. You’ll have your pick of webinar transcripts from recent DGU events - watch the webinar and edit the transcript to ensure accuracy and increase quality all while learning something new from DGU. The transcript will be delivered .txt or word format.\\n\\n **Context:** DigitalGov University is the federal government's training program for digital media and citizen engagement and is supports the digital strategy by hosting all the training associated with meeting the milestones. **Duration:** 2-4 hours **Deadline:** 2 weeks from the acceptance of the tapas."
+  },
+  {
+    "createdAt": "2013-06-10T21:02:11+00:00",
+    "name": "easy-source-code-clean-up-on-mobile-app-design-best-practices-mobile-gov-wiki-page",
+    "title": "Easy Source Code Clean Up on Mobile App Design Best Practices Mobile Gov Wiki Page",
+    "state": "completed",
+    "description": "**Tapas**: Please remove the SPAN tag formatting from the source code on the [Mobile Gov Wiki page Mobile App Design Best Practices](http://mobilegovwiki.howto.gov/Mobile+App+Design+Best+Practices).\n\n\\n\\n\n\n1. Click the “”Edit”” button to the right of the page title “PUT PAGE TITLE HERE\"\n\n2. Click the arrow button on the right-hand side of the “”Save”” button in the page editing tool bar\n\n3. Click on “”Wikitext Editor.”” This will switch you from the WYSIWYG editor to the source code\n\n4. Delete all of the <SPAN> tag coding.\n\n5. Save the page\n\nSee Mobile Gov Wiki’s “ [How to Remove the <SPAN> Tag](http://mobilegovwiki.howto.gov/How+to+Remove+the+%3CSPAN%3E+Tag)\"page for an illustrated explanation, and the [guidelines](http://mobilegovwiki.howto.gov/How+to+participate+in+the+Mobile+Gov+Wiki) on creating and editing pages in the Mobile Gov Wiki for further assistance.\n\nPlease note that while you do not need to be a member of the Mobile Gov Wiki (tho’ we’d like you to join), you do need a [Wikispaces](http://www.wikispaces.com/) account (user name, password and email).\n\n**Duration** : This task should take no more than 1 hour.\n\n**Deadline** :  Task should to be completed one week after acceptance."
+  },
+  {
+    "createdAt": "2013-06-10T21:01:51+00:00",
+    "name": "add-link-some-descriptive-text-to-data-driven-mobile-gov-wiki-page",
+    "title": "Add Link, Some Descriptive Text to Data-Driven Mobile Gov Wiki Page",
+    "state": "completed",
+    "description": "**Tapas**: Please link to the [Mobile Code Catalog](http://gsa.github.io/Mobile-Code-Catalog/) page from the [Data-Driven Mobile Gov Wiki Page](http://mobilegovwiki.howto.gov/Data-Driven+Mobile+Gov). Related Links section, and add a short 1 sentence description about each of the links in that section.\n\n\\n\\nSee the [guidelines](http://mobilegovwiki.howto.gov/How+to+participate+in+the+Mobile+Gov+Wiki) on creating and editing pages in the Mobile Gov Wiki.\n\nPlease note that while you do not need to be a member of the Mobile Gov Wiki (tho’ we’d like you to join), you do need a [Wikispaces account](http://www.wikispaces.com/) (user name, password and email).\n\n**Duration** : This task should take no more than 1 hour.\n\n**Deadline** :  Task should to be completed one week after acceptance."
+  },
+  {
+    "createdAt": "2013-06-10T21:01:29+00:00",
+    "name": "data-gov-validation-task",
+    "title": "Are These 20 Tools Categorized Correctly?",
+    "state": "completed",
+    "description": "******Tapas**: We all need validation, and Data.gov is no exception! We need to make sure we’ve got our tools categorized correctly so if interested, we will send you pick 20 tools from our list for you to check if the categories we picked are the right ones.\n\n\\n\\n **Duration** : Up to one hour.\n\n**Deadline:**  This is an ongoing task.  You can volunteer to do it once, or many times.\n\n**Context: **   [Data.gov](http://data.gov) is the nation’s one-stop shop for Federal government data. We have access to data from 172 agencies, along with apps and tools, gadgets and widgets.\n\nOver the past four years, this catalog has become a catch-all and we’re not really sure what’s in it. We know we’ve got widgets, gadgets, data extraction tools,and RSS feeds.  And maybe you’ll find something more!\n\nWhen we’ve got everything listed and categorized, we’ll know better how to catalog them — or if they’re still useful."
+  },
+  {
+    "createdAt": "2013-06-10T21:08:35+00:00",
+    "name": "update-the-mobile-webinar-series-wiki-page",
+    "title": "Update the Mobile Webinar Series Wiki Page",
+    "state": "completed",
+    "description": "**Tapas:** Please add links to all of the [mobile-focused webinars](http://www.howto.gov/training/on-demand#mobile) from September, 2012 onward, to the [Mobile Webinar Series Wiki Page](http://mobilegovwiki.howto.gov/Mobile+Webinar+Series).\\n\\nSee the [guidelines](http://mobilegovwiki.howto.gov/How+to+participate+in+the+Mobile+Gov+Wiki)  on creating and editing pages in the Mobile Gov Wiki. Please note that while you do not need to be a member of the Mobile Gov Wiki (tho’ we’d like you to join), you do need a [Wikispaces account](http://www.wikispaces.com/) (user name, password and email).\n\n**Duration** : This task should take no more than 1 hour.\n\n**Deadline** :  Task should to be completed one week after acceptance."
+  },
+  {
+    "createdAt": "2013-06-18T13:18:50+00:00",
+    "name": "edit-video-transcript-for-accuracy-2",
+    "title": "Edit Video Transcript for Accuracy",
+    "state": "completed",
+    "description": "**Tapas:** Review and edit a 60 min DigitalGov University webinar transcript. You’ll have your pick of webinar transcripts from recent DGU events – watch the webinar and edit the transcript to ensure accuracy and increase quality all while learning something new from DGU. The transcript will be delivered .txt or word format.\\n\\n **Context:**  DigitalGov University is the federal government’s training program for digital media and citizen engagement and is supports the digital strategy by hosting all the training associated with meeting the milestones. **Duration:**  2-4 hours **Deadline:**  2 weeks from the acceptance of the tapas."
+  },
+  {
+    "createdAt": "2013-06-18T13:47:17+00:00",
+    "name": "create-a-few-graphs-with-open-opportunities-stats",
+    "title": "Create a few graphs with Open Opportunities stats",
+    "state": "completed",
+    "description": "We need a few graphs to visualize some of the data that we've been collecting for the past few months for the Open Opportunities program. Some of the data include: number of volunteers and agencies participating, number of tasks completed so far and average time it takes volunteers to complete a task, among some others. We have the data! We just need someone to help us make some useful and \"\"pretty\"\" graphs so we can share it with our colleagues and bosses."
+  },
+  {
+    "createdAt": "2013-06-18T13:55:56+00:00",
+    "name": "developing-and-running-an-open-user-group-for-dap-google-analytics",
+    "title": "Developing and running an open user group for DAP Google Analytics",
+    "state": "completed",
+    "description": "**20%** : The user group would be open to any government employee to attend (to learn more about GA etc.), although the scope will be focused on Google Analytics and using it as part of DAP. We already have 29 participating agencies, more than 2000 websites, and nearly 400 individual users using DAP GA. So this user group would definitely be beneficial to support knowledge sharing, reporting tips and strategies, analysis topics etc. The format of the user group would be a monthly Webinar/phone conference. The content for each month would be led and coordinated by the volunteer, and task creator would attend the calls/Webinars to help answer questions, help with presentations etc. **Deadline** : Until assigned **Duration:**  6 months from accepting task"
+  },
+  {
+    "createdAt": "2013-06-25T14:36:40+00:00",
+    "name": "capture-and-share-api-success-story",
+    "title": "Capture and share an API success story",
+    "state": "completed",
+    "description": "****\n\n**Tapas:** This is a great opportunity for those with an inner journalist. Are you an \"intrepid reporter\" who wants to learn about APIs? If so, then this task is for you!\n\n\\n\\n **What are APIs**? An Application Programming Interface, or API, is the service and set of instructions that allows machine to machine communication—every mobile app and website widget that you come across is made possible by APIs.\n\nWe've identified some API stars and we need help to interview them, capture their stories, and publish them on HowTo.gov.\n\nBelow are brief questions for you to ask. Feel free to add your own too!\n\n1. \n\nWhat is your story?  (a brief description)\n\n2. \n\nWhat problem are you trying to solve?\n\n3. \n\nHow did you solve the problem?\n\n4. \n\nWhat are the results/impact?\n\nWe’ll give you the contact info for the person you're to interview. Your mission (if you chose to accept it) will be to conduct a brief interview (phone or in-person - your choice), capture the answers to the questions, type them up, and send them back. The HowTo team will turn your submission into a story/case study and publish on HowTo.gov.\n\n**Deadline** : One week after interview held.\n\n**Duration** : Up to 2 hours"
+  },
+  {
+    "createdAt": "2013-06-25T15:30:53+00:00",
+    "name": "basic-video-editing",
+    "title": "Basic Video Editing",
+    "state": "completed",
+    "description": "**Tapas** : Break down a 60 min DigitalGov University webinar recording, currently in a wmv format, into 3 separate and discrete videos. The videos should be able to stand alone and should be delivered in .wmv or .mp4 format with standard intros and outros (which the team will provide). The DGU team will provide direction as to where to cut/edit the video. **Context:**  DigitalGov University is the federal government's training program for digital media and citizen engagement and is supports the digital strategy by hosting all the training associated with meeting the milestones. **Duration:**  2-4 hours **Deadline:**  2 weeks from the acceptance of the tapas."
+  },
+  {
+    "createdAt": "2013-07-02T11:21:20+00:00",
+    "name": "mobile-gov-guest-blogger-for-trends-on-tuesday-posts",
+    "title": "Mobile Gov Guest Blogger for “Trends on Tuesday” Posts",
+    "state": "completed",
+    "description": "**20%:** Someone to write one “Trends on Tuesday” blog post per week for the Mobile Gov Blog. The blog consists of frequent, quick posts on one of the following what government is doing in mobile general mobile news, trends in mobile use, or issues on implementing mobile for the public.\\n\\nEvery Tuesday we feature a post on mobile user trends. Trends on Tuesday are kept simple, with a single trend. Posts should be composed in less than an hour to help keep focus on simplicity and speed. To complete your Trends on Tuesday tasks, you will find Pew or other credible, nonpartisan studies of mobile use or choose from a Digital Services Innovation Center list, and write a post about the trend(s). You will also review previous Trends on Tuesday posts for sources and not to repeat previous trends. Each post should include:\n- A link to the source of the trend (article, survey, etc)\n- A chart, graph or image depicting or representative of the trend\n- A link to resource(s) on the Mobile Gov Wiki\n- A concluding sentence about why this trend is important to government\n\n**Duration** : This task will take the volunteer up to 2 hours per week for 6 months.\n\n**Deadline** : TBD after accepting the task."
+  },
+  {
+    "createdAt": "2013-07-02T11:20:35+00:00",
+    "name": "create-a-mobile-gov-wiki-help-page-that-describes-how-to-add-alt-text-html-code-to-an-image",
+    "title": "Create a Mobile Gov Wiki Help Page that describes how to add Alt-Text HTML code to an Image",
+    "state": "completed",
+    "description": "**Tapas**: Please create a wiki help page describing how to add alt-text html code to images on the Mobile Gov Wiki. The wiki's image widget in the WYSIWYG editor only has a caption option that does not suffice for accessibility purposes, so we need an explanation of how to add the alt text tag using the Wikitext Editor function (html code) of the wiki page.\n\n\\n\\nPlease use the [How to Remove the <SPAN> Tag](http://gsablogs.gsa.gov//mobilegovwiki.howto.gov/How+to+Remove+the+%3CSPAN%3E+Tag) page as an example when creating the help page.\n\nSee Mobile Gov Wiki’s [guidelines](http://mobilegovwiki.howto.gov/How+to+participate+in+the+Mobile+Gov+Wiki) on creating and editing pages in the Mobile Gov Wiki for further assistance.\n\nPlease note that while you do not need to be a member of the Mobile Gov Wiki (tho’ we’d like you to join), you do need a [Wikispaces](http://www.wikispaces.com/) account (user name, password and email).\n\n**Duration** : This task should take no more than 2 hours.\n\n**Deadline** :  Task should to be completed one week after acceptance."
+  },
+  {
+    "createdAt": "2013-07-02T16:21:21+00:00",
+    "name": "analyze-metrics-to-evaluate-reach-and-success-of-dgu-programs",
+    "title": "Analyze metrics to evaluate reach and success of DGU programs",
+    "state": "completed",
+    "description": "******20%**: Help us improve DigitalGov University! We need someone to review metrics and user feedback, to identify opportunities to improve our training offerings.\\n\\nTasks include:\n- Review and share GovDelivery click-through data to determine elements of successful email campaigns that can be replicated for future events, and apply to future marketing efforts\n- Review web metrics for DGU content and identify opportunities to re-purpose content and promote on-demand course materials\n- Evaluate course survey results and identify opportunities to improve\n\n**Duration** : This task will take the volunteer up to 2 hours per week for 6 months.\n\n**Deadline** : TBD after accepting the task."
+  },
+  {
+    "createdAt": "2013-07-09T02:03:23+00:00",
+    "name": "add-some-data-and-a-picture-to-the-multilingual-mobile-mobile-gov-wiki-page",
+    "title": "Add Some Data and a Picture to the Multilingual Mobile Gov Wiki Page",
+    "state": "completed",
+    "description": "**Tapas**: Add some data on the [Multilingual Mobile Wiki page](https://mobilegovwiki.howto.gov/Multilingual+Mobile) on the uptake of mobile from non -English speakers (check Pew Internet project for some data and can also link to any relevant report.) Add a picture of the [Gobierno.usa.gov](http://www.usa.gov/gobiernousa/) mobile site (there’s a screen shot on the [apps.usa.gov](http://apps.usa.gov/) site)\n\n\\n\\nSee the [guidelines](http://mobilegovwiki.howto.gov/How+to+participate+in+the+Mobile+Gov+Wiki) on creating and editing pages in the Mobile Gov Wiki.\n\nPlease note that while you do not need to be a member of the Mobile Gov Wiki (tho' we'd like you to join), you do need a [Wikispaces](http://www.wikispaces.com/) account (user name, password, and email).\n\n**Duration** : Less than 1 hour\n\n**Deadline:**  Task should to be completed one week after acceptance.\n###"
+  },
+  {
+    "createdAt": "2013-07-09T01:59:36+00:00",
+    "name": "create-a-mobile-gov-wiki-page-called-data-mashups",
+    "title": "Create a Mobile Gov Wiki page called Data Mashups",
+    "state": "completed",
+    "description": "******Tapas**: First, provide a definition of data mashup and why it can be useful for mobile gov.  Next, provide the government example of the [recalls.gov](http://recalls.gov/) app.\n\n\\n\\nSee [the guidelines](http://mobilegovwiki.howto.gov/How+to+participate+in+the+Mobile+Gov+Wiki) on creating and editing pages in the Mobile Gov Wiki.\n\nPlease note that while you do not need to be a member of the Mobile Gov Wiki (tho’ we’d lke you to join), you do need a [Wikispaces](http://www.wikispaces.com/) account (user name, password and email).\n\n**Duration:** 2-4 hours\n\n**Deadline:** Task should be completed two weeks after acceptance."
+  },
+  {
+    "createdAt": "2013-07-09T10:31:35+00:00",
+    "name": "help-us-track-some-data-for-the-open-opportunities-program",
+    "title": "Help Us Track Some Data for the Open Opportunities Program",
+    "state": "completed",
+    "description": "**20%**: As you know, the Open Opportunities Program was launched 3 months ago. Since then, we've been tracking on a weekly basis and on a spreadsheet a few data points including number of new tasks added to the site, number of tasks assigned and completed, and number of volunteers, among some others.\\n\\nDo you like numbers? Do you have a few hours every week for the next 3 months to help us keep track of this data? If you do, let us know! **Duration:** 6 months - Through Feb 2014 **Deadline:  ** Ongoing"
+  },
+  {
+    "createdAt": "2013-07-11T14:00:42+00:00",
+    "name": "easy-source-code-clean-up-on-citizen-science-mobile-gov-wiki",
+    "title": "Easy Source Code Clean Up On Citizen Science Mobile Gov Wiki",
+    "state": "completed",
+    "description": "**Tapas:** Please remove the SPAN tag formatting from the source code on the [Mobile Gov Wiki page Citizen Science](http://mobilegovwiki.howto.gov/Citizen+Science).\n\n\\n\\n\n\n- Click the “”Edit”” button to the right of the page title “PUT PAGE TITLE HERE\"\n- Click the arrow button on the right-hand side of the “”Save”” button in the page editing tool bar\n- Click on “”Wikitext Editor.”” This will switch you from the WYSIWYG editor to the source code\n- Delete all of the <SPAN> tag coding.\n- Save the page\n\nSee Mobile Gov Wiki’s [“How to Remove the <SPAN> Tag](http://mobilegovwiki.howto.gov/How+to+Remove+the+%3CSPAN%3E+Tag)\" page for an illustrated explanation, and the [ guidelines](http://mobilegovwiki.howto.gov/How+to+Remove+the+%3CSPAN%3E+Tag) on creating and editing pages in the Mobile Gov Wiki for further assistance.\n\nPlease note that while you do not need to be a member of the Mobile Gov Wiki (tho’ we’d like you to join), you do need a [ Wikispaces](http://www.wikispaces.com/) account (user name, password and email). **Duration** : This task should take no more than 1 hour.\n\n**Deadline** :  Task should to be completed one week after acceptance."
+  },
+  {
+    "createdAt": "2013-07-15T19:34:44+00:00",
+    "name": "submit-questions-for-ask-gwynne-anything",
+    "title": "\"Ask Me Anything\" about Open Opportunities with Gwynne Kostin - Wednesday, July 24 at 11am EST",
+    "state": "completed",
+    "description": "**Tapas: [Sign up](https://www2.gotomeeting.com/register/120599690) today to participate and start asking your questions right below! For Feds only!**\n\nYou signed up for the Open Opportunities program and you've been checking out our tasks every week. So you probably understand the very basics of how Open Opportunities works (or maybe not?), but do you ever wish you could learn more or have a chance to talk with the team behind Open Opportunities?\n\nHere's your chance!\\n\\n\n\nGwynne Kostin, the head of the Digital Services Innovation Center and the visionary behind Open Opportunities, will be available on Wednesday, July 24 at 11 a.m., to answer your questions.\n\nYou can start submitting your questions by leaving them in the comments section below. Gwynne will answer you during the live session.\n\nSo  [sign up](https://www2.gotomeeting.com/register/120599690) today and ask away! **Duration:** Less than 5 minutes **Deadline:**  You can sign up until July 24"
+  },
+  {
+    "createdAt": "2013-07-16T02:58:26+00:00",
+    "name": "identify-digital-gov-conference-speakers-and-presentations-2",
+    "title": "Identify Digital Gov conference speakers and presentations",
+    "state": "completed",
+    "description": "**Tapas:**  Conduct a search of digital gov related presentations and speakers from the second quarter of this year (04-06 2013).\n\n**Instructions** : Browse the web to find conferences related to digital gov held in Jan-Mar. Topics may include but not limited to APIs, mobile, opening data, use of social media or analytics - and how their digital work has an impact on their stakeholders.\\n\\n **Deliverable** : In the text of an email, a Word or Excel doc, or a Google Doc include:\n- Name of event\n- \n\nName of the session/topic\n\n- \n\nSpeaker(s)\n\n- \n\nLink to event site\n\n- \n\nLink to event presentation or video of presentation, if available\n\n**Context:**  We will use this resource to identify digital innovators and their innovations that might otherwise fly under the radar. This task is important so agencies can see what others are doing to help spur ideas and learn from others' experiences. Some of these experiences might become best practices, blog posts or a followup webinar. It’s all part of the formula to help agencies jumpstart their efforts to build a 21st century digital government. You’ll help us make sure we don’t miss anything! Duration:  4 hours Deadline: Two weeks after the task is assigned"
+  },
+  {
+    "createdAt": "2013-07-16T02:57:56+00:00",
+    "name": "improve-dgus-on-demand-training-page",
+    "title": "Make DigitalGov U’s On-Demand Training Page Easier to Use",
+    "state": "completed",
+    "description": "**Tapas**: Please review the [DigitalGov University On-Demand Training page](http://www.howto.gov/training/on-demand) and provide a list of suggestions to improve the usability of this page.\\n\\nThe [HowTo.gov](http://www.howto.gov/) content team is unable to make IT development changes right now to have this page coded to be a dynamic, searchable, sort/filter content, but would like to make some immediate improvements to help users find the what they're looking for on this very long page. This page has lots of valuable resources and needs your ideas to improve its presentation and usability. **Duration:** 2-4 hours **Deadline: ** Two weeks after accepting the task or whatever time is negotiated."
+  },
+  {
+    "createdAt": "2013-07-16T02:57:20+00:00",
+    "name": "update-the-links-in-the-mobile-trends-and-research-mobile-gov-wiki-page",
+    "title": "Update the links in the Mobile Trends and Research Mobile Gov Wiki Page",
+    "state": "completed",
+    "description": "**Tapas**: Please [update the links in this page](http://mobilegovwiki.howto.gov/Mobile+Trends+and+Research) (some are returning 404 errors) and try to link to main pages rather than specific reports so that data does not become dated.  \\n\\nSee [the guidelines](http://mobilegovwiki.howto.gov/How+to+participate+in+the+Mobile+Gov+Wiki)  on creating and editing pages in the Mobile Gov Wiki. Please note that while you do not need to be a member of the Mobile Gov Wiki (tho’ we’d like you to join), you do need a  [Wikispaces account](http://www.wikispaces.com) (user name, password and email).\n\n**Duration** : 1 Hour\n\n**Deadline** : Task should be completed one week after acceptance."
+  },
+  {
+    "createdAt": "2013-07-16T02:56:57+00:00",
+    "name": "create-cross-links-between-the-performance-testing-resources-mobile-gov-wiki-page-and-other-related-pages",
+    "title": "Create cross links between the Performance Testing Resources Mobile Gov Wiki page and other related pages",
+    "state": "completed",
+    "description": "**Tapas**: Please create cross links between [this page](http://mobilegovwiki.howto.gov/Performance+Testing+Resources) and other related pages within the Mobile Gov Wiki.\n\n \\n\\nSee the [guidelines](http://mobilegovwiki.howto.gov/How+to+participate+in+the+Mobile+Gov+Wiki) on creating and editing pages in the Mobile Gov Wiki. Please note that while you do not need to be a member of the Mobile Gov Wiki (tho’ we’d lke you to join), you do need a  [Wikispaces account](http://www.wikispaces.com) (user name, password and email).\n\n**Duration** : Less Than 1 Hour\n\n**Deadline** : Task should be completed one week after acceptance"
+  },
+  {
+    "createdAt": "2013-07-16T02:56:33+00:00",
+    "name": "make-open-data-principles-real",
+    "title": "Find Examples of Open Data Principles In Action",
+    "state": "completed",
+    "description": "**Tapas**: This task asks you to scour websites, send emails to open-data teams (we'll help you with a list) and compile any policies, examples, web pages, that support any part of the seven [Open Data principles](http://project-open-data.github.io/principles/) from the White House Open Data Policy.\n\n\\n\\nSo, ask and then answer the questions \"\"how\"\" and \"\"what,\"\" for each clause of the meaty [principles](http://project-open-data.github.io/principles/).\n\nExample #1: Under the principle ACCESSIBLE: identify some specific formats that are accessible as defined. Bonus points to take it to the next level and show examples of agencies using those formats. Example #2: The principle DESCRIBED: find examples (links would be great) of data dictionaries. Of robust metadata. Of methods of data collection. Deliverable: A document (could be a spreadsheet, email, webpage, word or google doc) with the principles and examples tied to them. You can include links, or for policies that may not be online, include the documents, and, whenever possible agency names. Context: The White House released a ground-breaking Open Data Policy in May, including a set of [Open Data Principles](http://project-open-data.github.io/principles/) to guide agency efforts. It would help agencies immensely if they could see examples of these principles in action. The best way to jump start is to work from already existing examples--and it's also the best way to iterate and make new great examples **Duration** : 4-8 hours **Deadline** : 1 week or negotiable. The [seven open data principles](http://project-open-data.github.io/principles/) are:\n- Public\n- Accessible\n- Described\n- Reusable\n- Complete\n- Timely\n- Managed Post Release"
+  },
+  {
+    "createdAt": "2013-07-22T21:40:50+00:00",
+    "name": "create-cross-links-between-the-performance-testing-resources-mobile-gov-wiki-page-and-other-related-pages-2",
+    "title": "Create cross links between the Performance Testing Resources Mobile Gov Wiki page and other related pages",
+    "state": "completed",
+    "description": "**Tapas**: Please create cross links between [this page](http://mobilegovwiki.howto.gov/Performance+Testing+Resources) and other related pages within the Mobile Gov Wiki.\\n\\nSee the [guidelines](http://mobilegovwiki.howto.gov/How+to+participate+in+the+Mobile+Gov+Wiki) on creating and editing pages in the Mobile Gov Wiki. Please note that while you do not need to be a member of the Mobile Gov Wiki (tho’ we’d lke you to join), you do need a [Wikispaces](http://www.wikispaces.com/s) account (user name, password and email).\n\n**Duration** : Less Than 1 Hour\n\n**Deadline** : Task should be completed one week after acceptance"
+  },
+  {
+    "createdAt": "2013-07-22T21:40:09+00:00",
+    "name": "add-a-picture-to-the-mhealth-mobile-health-page-on-the-mobile-gov-wiki",
+    "title": "Add a Picture to the mHealth Mobile Health page on the Mobile Gov Wiki",
+    "state": "completed",
+    "description": "**Tapas:** Please find and insert an appropriate image for [the page](http://mobilegovwiki.howto.gov/mHealth+Mobile+Health).\n\n\\n\\nSee [the guidelines](http://mobilegovwiki.howto.gov/How+to+participate+in+the+Mobile+Gov+Wiki) on creating and editing pages in the Mobile Gov Wiki. Please note that while you do not need to be a member of the Mobile Gov Wiki (tho’ we’d lke you to join), you do need a  [Wikispaces](http://www.wikispaces.com/) account (user name, password and email).\n\n**Duration** : Less Than 1 Hour\n\n**Deadline** : Task should be completed one week after acceptance."
+  },
+  {
+    "createdAt": "2013-07-30T02:16:13+00:00",
+    "name": "add-a-picture-to-the-citizen-centric-government-page-on-the-mobile-gov-wiki",
+    "title": "Add a Picture to the Citizen-Centric Government page on the Mobile Gov Wiki",
+    "state": "completed",
+    "description": "**Tapas**: Please find and [insert an appropriate image](http://mobilegovwiki.howto.gov/Citizen-Centric+Government) for the page.\n\n\\n\\nSee the [guidelines](http://mobilegovwiki.howto.gov/How+to+participate+in+the+Mobile+Gov+Wiki) on creating and editing pages in the Mobile Gov Wiki.\n\nPlease note that while you do not need to be a member of the Mobile Gov Wiki (tho’ we’d lke you to join), you do need a  [Wikispaces](http://www.wikispaces.com/)  account (user name, password and email).\n\n**Duration** : Less Than 1 Hour\n\n**Deadline** : Task should be completed one week after acceptance."
+  },
+  {
+    "createdAt": "2013-07-30T02:17:29+00:00",
+    "name": "add-a-picture-to-the-camera-page-on-the-mobile-gov-wiki",
+    "title": "Add a Picture to the Camera Page on the Mobile Gov Wiki",
+    "state": "completed",
+    "description": "**Tapas**: Please find and [insert an appropriate image](http://mobilegovwiki.howto.gov/Camera) for the page (possibly one of many people taking photos with their phone.) See the [guidelines](http://mobilegovwiki.howto.gov/How+to+participate+in+the+Mobile+Gov+Wiki) on creating and editing pages in the Mobile Gov Wiki.\n\n\\n\\nPlease note that while you do not need to be a member of the Mobile Gov Wiki (tho’ we’d lke you to join), you do need a  [Wikispaces](http://www.wikispaces.com/) account (user name, password and email).\n\n**Duration** : Less Than 1 Hour\n\n**Deadline** : Task should be completed one week after acceptance"
+  },
+  {
+    "createdAt": "2013-07-30T02:16:40+00:00",
+    "name": "trolling-for-federal-microvolunteering-and-crowdsourcing-projects",
+    "title": "Trolling for federal microvolunteering and crowdsourcing projects",
+    "state": "completed",
+    "description": "**Tapas**: Spend an hour or so looking for federal agencies using micro & macrovolunteering and crowdsourcing for mission related purposes.\n\n\\n\\n **Instructions: ** Put the URL for the  initiative _ **directly in the comments for this post** _. Include your name and agency affiliation (so we can acknowledge your contribution).\n\n**Examples** :\n\n- [Citizen Archivist](http://www.archives.gov/citizen-archivist/)\n- [Virtual Student Foreign Service](http://www.state.gov/vsfs/)\n- [Smithsonian Digital Volunteers](https://transcription.si.edu/),\n- See also, [Government Crowdsourcing](http://en.wikipedia.org/wiki/Government_crowdsourcing) on Wikipedia\n**Context: ** We will use this resource to form a user group of federal agencies using (or interested in using) crowdsourcing and microvunteering to complete their mission. This task is important so agencies can see what others are doing to help spur ideas and learn from others' experiences. Some of these experiences might become best practices, blog posts or a followup webinar. It’s all part of the formula to help agencies jumpstart their efforts to build a 21st century digital government. You’ll help us make sure we don’t miss anything! **Duration** :  1 hour **Deadline** : This is an ongoing task.  You can volunteer to do it once, or many times."
+  },
+  {
+    "createdAt": "2013-08-06T18:31:59+00:00",
+    "name": "reformat-the-real-world-and-types-of-testing-sections-on-the-guidelines-to-testing-mobile-gov-wiki-page",
+    "title": "Reformat the “Real World” and “Types of Testing” sections on the Guidelines to Testing Mobile Gov Wiki Page",
+    "state": "completed",
+    "description": "**Tapas:** The sections use numbers, change the subsections within these sections to either bullets or letters.  Please see the  [guidelines](http://mobilegovwiki.howto.gov/How+to+participate+in+the+Mobile+Gov+Wiki) on creating and editing pages in the Mobile Gov Wiki.\n\n\\n\\n_Please note that while you do not need to be a member of the Mobile Gov Wiki (tho’ we’d like you to join), you do need a  [Wikispaces](http://www.wikispaces.com/) account (user name, password and email)._\n\n**Duration:**  1-2 hours\n\n**Deadline: ** Task should be completed less than one week after acceptance."
+  },
+  {
+    "createdAt": "2013-08-06T18:35:29+00:00",
+    "name": "alphabetize-the-resourcesservices-under-each-section-of-the-functionality-and-usability-testing-resources-mobile-gov-wiki-page",
+    "title": "Alphabetize the Resources/Services Under Each Section of the Functionality and Usability Testing Resources Mobile Gov Wiki Page",
+    "state": "completed",
+    "description": "**Tapas: **There are various sections of the page, please rearrange the resources/services listed from A-Z in the following sections: Government Guidance, Web Resources, Relevant Communities, Mobile Resources, and Web Resources. Please see the  [guidelines](http://mobilegovwiki.howto.gov/How+to+participate+in+the+Mobile+Gov+Wiki) on creating and editing pages in the Mobile Gov Wiki.\n\n_\\n\\nPlease note that while you do not need to be a member of the Mobile Gov Wiki (tho’ we’d like you to join), you do need a  [Wikispaces](http://www.wikispaces.com/) account (user name, password and email)._\n\n**Duration:**  1-2 hours\n\n**Deadline:**  Task should be completed less than one week after acceptance."
+  },
+  {
+    "createdAt": "2013-08-19T21:21:07+00:00",
+    "name": "seeking-a-user-experience-andor-visual-design-expert",
+    "title": "Seeking a user experience and/or visual design expert",
+    "state": "completed",
+    "description": "**20%:** Help with creating a visual design style guide (logo, fonts, colors, etc) and general user experience design. If you have experience as a web designer, information architect or user experience expert, this project is a great opportunity to show your talent!\n\n\\n\\n **Context** : Open Opps is adding support for the White House's Presidential Innovation Fellows. This project is part of the Innovation Toolkit [[http://www.whitehouse.gov/innovationfellows/innovation-toolkit](http://www.whitehouse.gov/innovationfellows/innovation-toolkit)], and will support the platform being developed for the Dept of State to be used by other agencies.\n\n**Duration:** 3-6 months\n\n**Deadline** : Ongoing\n\n**Deadline** : Ongoing"
+  },
+  {
+    "createdAt": "2013-08-19T21:19:28+00:00",
+    "name": "design-a-badge-for-the-open-opportunities-wall-of-fame",
+    "title": "Design a \"Founders\" Badge for the Open Opportunities Wall of Fame",
+    "state": "completed",
+    "description": "**Tapas: ** We need a \"Founders\" badge to give special recognition the Open Opportunity volunteers that have been with us from the beginning. Please design and send us a badge adhering to a look and feel similar to the already existing Tapas & 20% badges currently on the Wall of Fame. ( [http://gsablogs.gsa.gov/dsic/category/wall-of-fame](http://gsablogs.gsa.gov/dsic/category/wall-of-fame/)). **Duration** : 2-4 hours **Deadline** : 2 weeks after accepting the task"
+  },
+  {
+    "createdAt": "2013-08-27T00:41:25+00:00",
+    "name": "mobile-gov-guest-blogger-for-mobile-product-thursday",
+    "title": "Mobile Gov guest blogger for “Mobile Product Thursday”",
+    "state": "completed",
+    "description": "**20%**: Someone to help improve mobile implementations by writing the “Mobile Product Thursday” weekly blog post for the  [Mobile Gov Blog](http://howtomobile.apps.gov/). The blog consists of frequent, quick posts on what government is doing in mobile, general mobile news, trends in mobile use, and issues on implementing mobile for the public.\\n\\nEvery Thursday we feature a post on government mobile products. Mobile product blogs are kept simple, with a single trend. Posts should be composed in less than an hour to help keep focus on simplicity and speed. Refer to the  [USA.gov Apps Gallery](http://apps.usa.gov/) for ideas, work with Digital Services Innovation Center for features on newer mobile products (app, mobile web, etc.) and write a post about a new mobile product. You will have to check previous posts to make sure your proposed post has recently been blogged about. Each post should include a:\n- Link to the agency who developed the app/site\n- Brief description about what the app does\n- Screen shot of the app\n- Link to the app in USA.gov Apps Gallery or the agency’s page advertising the app\n**Duration: ** Up to 2 hours per week for 4-6 months **Deadline: ** TBD after accepting the task"
+  },
+  {
+    "createdAt": "2013-09-24T21:41:46+00:00",
+    "name": "create-a-location-map-of-open-opportunities-volunteers",
+    "title": "Create a Location Map of Open Opportunities Volunteers",
+    "state": "completed",
+    "description": "**Tapas: **Create an interesting and colorful map that shows the location of our open Opportunities  LinkedIn volunteers. **Context:**   We want to be able to see where our volunteers reside. **Deadline:** 2 weeks after accepting the task **Duration:** 4 hours"
+  },
+  {
+    "createdAt": "2013-09-03T16:33:41+00:00",
+    "name": "help-us-develop-government-wide-open-content-models",
+    "title": "Help us Develop Government-Wide Open Content Models",
+    "state": "completed",
+    "description": "**20%** : Content models define the structure of information products and their constituent content components. Developing shared and open content models enable content producers to make their content [more adaptive and shareable](http://www.howto.gov/web-content/technology/content-management-systems/how-to-create-open-structured-content) and “future-ready.”\n\n\\n\\nThe Digital Services Innovation Center would like to create shared content models for use in the federal government. The proper candidate will help us complete the following deliverables to increase the expertise around and use of shared and open content models in the federal government.\n\n- \n\nResearch & document existing private sector content modeling types and other relevant practices\n\n- \n\nHost “First level of discovery” event to identify common types of government content models\n\n- \n\nIdentify potential popular/relevant government content models\n\n- \n\nFor most popular-- create government-wide content model(s) with other interested individuals\n\n- \n\nPromote awareness around effort\n\n- Create ongoing community/network around content modeling in order to set up ability/environment to create other relevant government wide content models\n**Duration** : 6 months **Deadline** : Ongoing"
+  },
+  {
+    "createdAt": "2013-09-04T03:23:50+00:00",
+    "name": "update-the-past-events-page-on-the-mobile-gov-wiki",
+    "title": "Update the Past Events page on the Mobile Gov Wiki",
+    "state": "completed",
+    "description": "**Tapas: **Please update the Past Events page [[http://mobilegovwiki.howto.gov/Past+Events](http://mobilegovwiki.howto.gov/Past+Events)] with descriptions of events held Feb-Aug 2013 and linking to either the respective blog post or webinar page.\n\nOnce you have accept this task, we’ll send you a list of the events and you will be responsible for writing a brief description of the event.\n\n\\n\\n\n\nPlease note that while you do not need to be a member of the Mobile Gov Wiki (tho’ we’d like you to join), you do need a  [Wikispaces](http://www.wikispaces.com/) account (user name, password and email).\n\nDuration: 2-4 hours\n\nDeadline: Task should be completed within one week after acceptance."
+  },
+  {
+    "createdAt": "2013-09-09T19:04:22+00:00",
+    "name": "create-a-new-badge-design-in-html-for-the-wiki-badge-hall-of-fame-page-on-the-mobile-gov-wiki",
+    "title": "Create a New Badge Design in HTML For the Wiki Badge Hall of Fame Page on the Mobile Gov Wiki",
+    "state": "completed",
+    "description": "**Tapas:** This badge will be awarded to individuals who host a Mobile Gov Wikithon. Users can earn badges for their participation in the Making Mobile Gov Wiki. Special badges are one time awards for participation in a special event or activity. Visit our Wiki Badges to view other badges.\\n\\nOnce you accept this task, you will have a discussion with the task manager to brainstorm the proper badge. You will then design that badge and submit it for completion. Please note that while you do not need to be a member of the Mobile Gov Wiki (tho’ we’d like you to join), you do need a Wikispaces account (user name, password and email). **Duration:** 2-4 hours **Deadline:** Task should be completed less than one week after acceptance."
+  },
+  {
+    "createdAt": "2013-09-10T17:14:05+00:00",
+    "name": "open-opportunities-an-innovative-new-volunteer-program-has-completed-the-pilot-stage-want-to-help-us-move-to-the-next-level",
+    "title": "Operations Manager to Help Open Opportunities Program Goals",
+    "state": "completed",
+    "description": "**20%**: We are looking for a detail oriented problem solver who can  to become part of the management team for Phase II of the Open Opportunities program as we grow. Phase II will include expanding to a wider audience of volunteers across government, improving the platform and doing more marketing and outreach.  Some of the tasks might include:\\n\\n\n- Developing promotional and communication messages\n- Identifying and reaching out to key stakeholders\n- Work with task creators\n- Publish tasks on Open Opportunities page\n- Monitor and answer questions and comments that might come in via email and the blog\n- Communicate with volunteers\n- Suggest ideas to improve the platform or the business process\n- Recognize volunteers via blog, GovD & tweets\n**Duration:** This task will take 20% of the volunteers time over the next 6 months. **Deadline:** Ongoing"
+  },
+  {
+    "createdAt": "2013-09-13T20:09:51+00:00",
+    "name": "open-opportunities-mobile-application-testing-program-monthly-newsletter-writereditor",
+    "title": "Open Opportunities Mobile Application Testing Program Monthly Newsletter Writer/Editor",
+    "state": "completed",
+    "description": "**20%er**: Testers in the  [**Open Opportunities Mobile Application Testing Program**](http://gsablogs.gsa.gov/dsic/get-it-done/mobile-application-development-program/open-opportunities-mobile-application-testing-program/) get the opportunities to learn from each other and share ideas. One way will be via a monthly newsletter that will be distributed to testers to keep them up to date on current topics related to mobile application testing. We would like a Writer/Editor to help write/edit the newsletter each month.\\n\\nTasks will include:\n- Planning newsletter content with the Crowd-Source Testing Management Team\n- Collecting and curating information for a monthly newsletter;\n- Preparing content for dissemination\n- Writing and/or editing a feature article each month for the newsletter\n**Duration** : Up to 8 hours per month for 6 months. **Deadline:**  This is an ongoing task."
+  },
+  {
+    "createdAt": "2013-09-17T18:30:44+00:00",
+    "name": "write-a-mobile-gov-experience-on-the-launch-of-studentaid-gov-for-the-mobile-gov-wiki",
+    "title": "Write a Mobile Gov Experience on the launch of StudentAid.gov for the Mobile Gov Wiki",
+    "state": "completed",
+    "description": "Following the [Mobile Gov Experience Template](http://mobilegovwiki.howto.gov/Mobile+Gov+Experience+Template), use the blog posts [StudentAid.gov: Improving the College Financing Experience](http://blog.howto.gov/2013/09/06/studentaid-gov-improving-the-college-financing-experience/) and [StudentAid.gov’s 1st Year: What We’ve Learned and Where We’re Going](http://blog.howto.gov/2013/09/13/studentaid-govs-1st-year-what-weve-learned-and-where-were-going/), to draft a Mobile Gov Experience on StudentAid.gov. Please see the [guidelines](http://mobilegovwiki.howto.gov/How+to+participate+in+the+Mobile+Gov+Wiki) on creating and editing pages in the Mobile Gov Wiki.\n\nYou can submit your draft via email or attached Word doc.\n\n**Duration:** 2-4 hours\n\n**Deadline:** Task should be completed within two weeks after acceptance."
+  },
+  {
+    "createdAt": "2013-09-26T02:06:26+00:00",
+    "name": "write-a-guest-blog-post-about-your-experience-at-the-open-opps-tapathon",
+    "title": "Write a Guest Blog Post About Your Experience at the Open Opps Tapathon",
+    "state": "completed",
+    "description": "**Tapas**: Open opportunities held a \"Tapa-thon\" on September 24 bringing federal innovators together work on tapas tasks with other volunteers and learn more about the program.\n\nWrite a blog post about your experience.\n\n**Duration:** Up to 2 hours.\n\n**Deadline** : One week after accepting the task."
+  },
+  {
+    "createdAt": "2013-09-26T02:32:12+00:00",
+    "name": "design-a-badge-for-the-wall-of-fame-to-show-participation-at-the-first-open-opps-tapathon",
+    "title": "Design a Badge for the Wall of Fame to Show Participation at the First Open Opps Tapathon",
+    "state": "completed",
+    "description": "**Tapas** : We need a \"Tapa-thon\" badge to give special recognition the Open Opportunity volunteers that attended the first Tapathon. Design and send us a badge adhering to a look and feel similar to the already existing Tapas & 20% badges currently on the Wall of Fame. ( [http://gsablogs.gsa.gov/dsic/category/wall-of-fame](http://gsablogs.gsa.gov/dsic/category/wall-of-fame)). **Duration** : 2-4 hours **Deadline** : One week after accepting the task"
+  },
+  {
+    "createdAt": "2013-10-29T00:52:16+00:00",
+    "name": "product-manager-sites-usa-gov-2",
+    "title": "Product Manager for sites.usa.gov",
+    "state": "completed",
+    "description": "**Agency Rep**: The Product Manager is responsible for product planning, development and support for [sites.usa.gov](http://sites.usa.gov). sites.usa.gov is a shared service to help agencies focus on creating great content rather than on building systems to deliver that content. This includes managing the product throughout the product lifecycle, gathering and prioritizing product and customer requirements, developing the product vision, and working closely with customers and developers to deliver a successful service. It also includes working with the Digital Services Innovation Center team and leadership as well as OMB to ensure that growth and customer satisfaction goals are met. The Product Manager’s job also includes ensuring that the product and marketing efforts support the overall goals of the Federal Digital Strategy and supporting policies.\\n\\n\n\nsites.usa.gov Product Manager roles and responsibilities:\n- \n\nProduct development\n\n  - \n\nDefine the product strategy and roadmap.\n\n  - \n\nDeliver marketing requirements and product requirements documents with prioritized features and corresponding justification, to include features, templates, themes.\n\n  - \n\nWork closely with technical team to deliver features on 30-day product development cycles\n\n  - \n\nDevelop systems to solicit and gather client (and potential client) feedback to drive speedy, agile product development\n\n  - \n\nCreate, test and implement customer experience model with goal of automated, self-service commissioning of sites\n\n  - \n\nWith technical team and clients develop policy and process to leverage client developed themes, plugins, etc.\n\n- \n\nOperations and Service\n\n  - \n\nPropose an overall operations model (budget, staffing)  to ensure success\n\n  - \n\nGuide onboarding of new clients\n\n  - \n\nAssist in setting of pricing and service options to meet self-funding goals\n\n  - \n\nDeliver with Marketing Lead a monthly/quarterly customer/reimbursement forecast\n\n- \n\nAct as a catalyst for agency adoption of open content management.\n\n- \n\nCoordinate with MarCom Lead on product demos and programs"
+  },
+  {
+    "createdAt": "2013-10-29T01:08:21+00:00",
+    "name": "marketing-lead-sites-usa-gov",
+    "title": "Marketing Lead sites.usa.gov",
+    "state": "completed",
+    "description": "**20%**: The Marketing Lead is responsible for marketing and communications for [sites.usa.gov](http://sites.usa.gov) with the goal of developing growing a self-sufficient service with a vibrant user-community. sites.usa.gov is a shared service to help agencies focus on creating great content rather than on building systems to deliver that content. The Marketing Lead will work closely with the Digital Services Innovation Center team and leadership as well as OMB to ensure that growth and customer satisfaction goals are met. The Product Manager’s job also includes ensuring that the product and marketing efforts support the overall goals of the Federal Digital Strategy and supporting policies.\\n\\n\n\nSpecifically, the Marketing Lead will:\n- \n\nDevelop and implement customer acquisition plan with Center leadership\n\n- \n\nDevelop the core positioning and messaging for the product with Center comms and leadership\n\n- \n\nDevelop marketing tools and collateral with Center comms and leadership\n\n- \n\nCommunicate updates and improvements to current and future clients\n\n- \n\nUpdate sites.usa.gov with information on new features\n\n- \n\nCoordinate and help with collateral for product demos and other presentations for potential clients\n\n- \n\nInvestigate and implement models to encourage customer community sharing especially around support issues\n\n- \n\nDevelop customer experience metrics and evaluation tools\n\n- \n\nDeliver with Marketing Lead a monthly/quarterly customer/reimbursement forecast\n\n- Participate in product planning and update meetings both to keep abreast of the product as well as to advise on product direction."
+  },
+  {
+    "createdAt": "2013-11-12T20:12:57+00:00",
+    "name": "copy-edit-the-promotions-mobile-gov-wiki",
+    "title": "Copy edit the Promotions Mobile Gov Wiki",
+    "state": "completed",
+    "description": "**Tapas**: Please copy edit the [Promotions Mobile Gov Wiki](http://mobilegovwiki.howto.gov/Promotion) page to:\n\n1. \n\nclean up the formatting\n\n2. \n\nverify the publications are still publishing and relevant to mobile gov and add other new publications\n\n3. add an appropriate image\\n\\n\n\nSee the [guidelines](http://mobilegovwiki.howto.gov/How+to+participate+in+the+Mobile+Gov+Wik)on creating and editing pages in the Mobile Gov Wiki. Please note that while you do not need to be a member of the Mobile Gov Wiki (tho’ we’d like you to join), you do need a [Wikispaces account](http://www.wikispaces.com) (user name, password and email).\n\nOnce accepted, we'll email you the specifics about which publications and the graphic.\n\n**Duration:** 1 - 2 hours\n\n**Deadline:** 1 week after task is assigned."
+  },
+  {
+    "createdAt": "2013-11-12T20:37:54+00:00",
+    "name": "copy-edit-the-mobile-testing-101-mobile-gov-wiki",
+    "title": "Copy edit the Mobile Testing 101 Mobile Gov Wiki",
+    "state": "completed",
+    "description": "**Tapas**: Please copy edit the [Mobile Testing 101 Mobile Gov Wiki](http://mobilegovwiki.howto.gov/Mobile+Testing+101)page by:\n- \n\nadding headers,\n\n- \n\nshrinking the images slightly so that the page doesn't scroll horizontally,\n\n- \n\nreformatting all links so they are in plain English, not the hyperlinked URL and\n\n- \n\ngeneral copy editing\\n\\n\n\nSee the [guidelines](http://mobilegovwiki.howto.gov/How+to+participate+in+the+Mobile+Gov+Wiki)on creating and editing pages in the Mobile Gov Wiki. Please note that while you do not need to be a member of the Mobile Gov Wiki (tho’ we’d like you to join), you do need a [Wikispaces](http://www.wikispaces.com/) account (user name, password and email).\n\nOnce accepted, we'll chat with you about the specifics of the task. **Duration** : 1 - 2 hours **Deadline:** 1 week after task is assigned."
+  },
+  {
+    "createdAt": "2013-11-12T20:46:29+00:00",
+    "name": "get-to-know-south-dakota",
+    "title": "Let Your Inner Data Detective out and Get to Know South Dakota",
+    "state": "completed",
+    "description": "**Tapas**: USA.gov searches across all federal, state, and local government websites--that’s hundreds of billions of pages from .gov and .mil websites plus [over 11,000 .com, .org, etc. websites](http://govt-urls.usa.gov/tematres).\n\nData detectives, here's where you come in. We need you to help us improve the results searchers on USA.gov see for the state of South Dakota.\\n\\nUSA.gov searches across all federal, state, and local government websites--that’s hundreds of billions of pages from .gov and .mil websites plus [over 11,000 .com, .org, etc. websites](http://govt-urls.usa.gov/tematres). Here's your chance to improve the results searchers on USA.gov see for the state of South Dakota. 1. Once you let us know that you’re interested, we’ll give you access to edit the 75 known S.D. websites directly: [http://govt-urls.usa.gov/tematres/vocab/index.php?tema=163](http://govt-urls.usa.gov/tematres/vocab/index.php?tema=163)2. Your task is to visit the website for each S.D. city, county, and state agency. 3. Review the website to make sure it still belongs to an official government agency, and add a scope note to provide some basic bibliographic information about the agency. 4. If you want to try this out but can’t tackle all the links, let us know! We still want to hear from you! Perfect for librarians, catalogers, or those who want to take a virtual tour of the Mount Rushmore state."
+  },
+  {
+    "createdAt": "2013-12-04T18:47:08+00:00",
+    "name": "help-us-build-a-new-platform-for-open-opps",
+    "title": "Help Us Build A WordPress Platform for Open Opps",
+    "state": "completed",
+    "description": "**20%: **Open Opportunities is getting ready to upgrade to a more \"customized\" platform. We're looking for a developer with Wordpress experience to lead the charge and get us there. We've already identified the features that we would like to add to our platform, and two people that would like to help out, but we need you to pull it together and make it all happen! We will provide a detailed outline of what is required to anyone interested in learning what the project entails.\\n\\n **Duration: ** 20% of the innovator's time for 6 months **Deadline: ** 6 months after the task starts (there's flexibility with this timeframe!)"
+  },
+  {
+    "createdAt": "2013-12-11T01:33:33+00:00",
+    "name": "desperately-seeking-creative-writercommunications-guru",
+    "title": "Communications Guru for Open Opportunities",
+    "state": "completed",
+    "description": "**20%er: ** We are looking for a Creative Writer Communications Guru to collaborate with the Open Opportunities team and help us spread the word and grow our network.\n\n\\n\\nWork will include:\n- \n\nCreating messaging that fits our goals and executing that messaging through compelling storytelling.\n\n- Helping finalize our communications and outreach strategy\n- \n\nAdvocating the program and helping the team expand the network\n\n- Developing and promoting content for our newsletter, blog, Facebook, Twitter etc...\n- \n\nAttending periodic team meetings and coordinating with the team as needed (we will be flexible based on your availability)\n\nIf you are a communicator, creative writer or storyteller this opportunity is for you. **Duration** : 20% of the innovator’s time for 3 - 6 months **Deadline:** Ongoing (to be negotiated)"
+  },
+  {
+    "createdAt": "2013-12-17T22:12:09+00:00",
+    "name": "design-an-agency-rep-badge-for-the-open-opportunities-wall-of-fame",
+    "title": "Design an \"Agency Rep\" Badge for the Open Opportunities Wall of Fame",
+    "state": "completed",
+    "description": "**Tapas: ** We need an “Agency Rep” badge to give special recognition the Open Opportunity innovators who have work with us for a significant period of time. Please design and send us a badge adhering to a look and feel similar to the already existing Tapas & 20% badges currently on the Wall of Fame. ( [http://gsablogs.gsa.gov/dsic/category/wall-of-fame](http://gsablogs.gsa.gov/dsic/category/wall-of-fame/)). **Duration** : 2-4 hours **Deadline** : 2 weeks after accepting the task"
+  },
+  {
+    "createdAt": "2013-12-19T02:25:59+00:00",
+    "name": "develop-a-sow-for-enhancing-the-open-opps-site",
+    "title": "Develop a SOW for Enhancing the Open Opps Site",
+    "state": "completed",
+    "description": "**Tapas**: We need someone to develop a clear and concise SOW for enhancing our Open Opportunities Wordpress platform.  To help you we have developed a list requirements and prioritized them. We need the requirements categorized in sequential order with:\\n\\n\n- Tasks and deliverables\n- Tasks in sequential order, methodology, specifications/performance requirements, standards\n- Approximate hours required to complete each task\n- Work products, acceptance criteria\n**Duration: 2 - 4 hours**** Deadline**: Within two weeks of accepting the tasks"
+  },
+  {
+    "createdAt": "2014-02-11T13:09:22+00:00",
+    "name": "community-manager-for-open-opportunities-linkedin-group",
+    "title": "Community Manager for Open Opportunities LinkedIn Group",
+    "state": "completed",
+    "description": "**20%: **Open Opportunities launched its [LinkedIn group](http://www.linkedin.com/groups?home=&gid=5016512&trk=anet_ug_hm&goback=%2Egna_5016512) a few months ago and already almost 100 of our subscribers are part of this community. The Open Opportunities team is ready to take this LinkedIn community to another level and is looking for help! The goal is to build an engaged network of government innovators. \\n\\nIf you have:\n- a passion for community management\n- an interest in interacting with one of the coolest communities in government\n- creative flair for developing \"small scale\" campaigns on LinkedIn\nWe want to hear from you! Some duties include:\n- sending regular announcements\n- starting and monitoring discussions\n- getting to know the members and recognize them\n- highlighting great things happening around government\n- being the face of Open Opportunities on the platform"
+  },
+  {
+    "createdAt": "2014-02-12T17:19:44+00:00",
+    "name": "create-a-short-video-of-open-opportunitiy-innovator-experiences",
+    "title": "Create a short video of Open Opportunity Innovator Experiences",
+    "state": "completed",
+    "description": "**Tapas**: Oversee the creation and production of a short video about the experiences of Open Opportunities innovators. The Open Opportunities team wants to tell the story of the fabulous work that has been done and the benefits received by the participants and their agencies.\n\n\\n\\n\n\nTasks include but are not limited to:\n- \n\nGuiding the creative process and collaborating with the videographer\n\n- \n\nContacting interview subjects, organizing video times, arranging for interpreter, conducting the interview during the filming\n\n- \n\nDeveloping interview questions\n\n- \n\nWorking with the interviewees to make sure they have prepared answers and the videographer.\n\n- \n\nDrafting a blog post about the experience (if useful)\n\n**Deadline** : Video must be complete by February 27, 2014 **Duration** : 4-8 hours"
+  },
+  {
+    "createdAt": "2014-02-12T18:04:16+00:00",
+    "name": "tell-open-opportunities-stories",
+    "title": "Help us tell Open Opportunities stories",
+    "state": "completed",
+    "description": "**Tapas**: The Open Opportunities program is looking for a few good  storytellers. Like so many other good news stories in government ours has not been told and we want to get the word out. We need you to take the nuggets in our work and help us tell our stories.\n\n\\n\\n\n\nThe stories created can be told many different ways including creating a presentation, writing a blog post, doing a video or using social media. Sometimes you will tell the story using your own voice and sometimes it may require you to encourage others to tell their stories.\n\nThe ideal person is someone who believes in the Open Opportunities program and its ability to help build a 21st Century government. We want you to help us share with innovators across government who we are, what we do, and the impact we have.\n\nWe need you to\n\n- Pick a story from our pilot (we have collected lots of them to start with)\n- \n\nDecide the most effective medium to tell the story (for ex, words, pictures, video)\n\n- \n\nJudge and relay the impact of those stories\n\nDeliverables may include powerpoints, interviews blog posts, case studies,s etc. Specifics will be determined with the open opportunities team.\n\nInterested? Just click the blue button!.\n\n**Duration** : 2-4 hours\n\n**Deadline** : Negotiable"
+  },
+  {
+    "createdAt": "2014-02-12T18:14:34+00:00",
+    "name": "mobilegov-guest-blogger-for-trends-on-tuesday",
+    "title": "MobileGov guest blogger for “Trends on Tuesday”",
+    "state": "completed",
+    "description": "**20%**: Let your federal colleagues know the latest trends in mobile adoption by writing [“Trends on Tuesday” blog posts](http://www.digitalgov.gov/category/mobile/) for the DigitalGov Platform.\\n\\nThis position makes you a writer for the mobile channel which focuses on general mobile news, trends in mobile use and agency challenges and solutions for implementing mobile products like apps, responsive web design, SMS and mobile websites for the public. Every Tuesday we feature a post on mobile user trends. Trends on Tuesday are kept simple, with a single trend. Posts should be composed in less than an hour to help keep focus on simplicity and speed.\nTo complete your Trends on Tuesday tasks, you will find Pew or other credible, nonpartisan studies of mobile use or choose from a Digital Services Innovation Center list, and write a post about the trend(s). You will also review previous Trends on Tuesday posts for sources and not to repeat previous trends. Each post should include:\n- A link to the source of the trend (article, survey, etc)\n- A chart, graph or image depicting or representative of the trend\n- A link to resource(s) on the Digital Gov platform\n- A concluding sentence about why this trend is important to government\n\n**Duration** : This task will take the volunteer up to 2 hours per week for 6 months. We are looking for you to write at least 3-4 posts a month.\n\n**Deadline** : TBD after accepting the task."
+  },
+  {
+    "createdAt": "2014-02-26T19:49:09+00:00",
+    "name": "create-a-location-map-of-open-opportunities-innovators",
+    "title": "Create a map showing where Open Opportunities innovators are located",
+    "state": "completed",
+    "description": "**Tapas: **Create an interesting and colorful map that shows the location of our open Opportunities innovators in eight cities across the US including:\\n\\n\n- Baltimore, MD\n- Indianapolis, IN\n- Boulder, CO\n- Cincinnati, OH\n- Dayton, OH\n- Charleston, SC\n- Binghamton NY\n- Washington DC\n**Context:**   We want to be able to see our volunteers and where our volunteers reside. **Deadline:**  2 weeks after accepting the task **Duration:** 2 hours"
+  },
+  {
+    "createdAt": "2014-03-04T21:44:55+00:00",
+    "name": "let-your-inner-data-detective-out-and-get-to-know-maryland",
+    "title": "Let Your Inner Data Detective out and Get to Know Maryland",
+    "state": "completed",
+    "description": "**Tapas**: USA.gov searches across all federal, state, and local government websites--that’s hundreds of billions of pages from .gov and .mil websites plus [over 11,000 .com, .org, etc. websites](http://govt-urls.usa.gov/tematres).\n\n\\n\\n\n\nHere's your chance to improve the results searchers on USA.gov see for the state of Maryland.\n\n1. Once you let us know that you’re interested, we’ll give you access to edit the known Maryland websites directly: [http://govt-urls.usa.gov/tematres/vocab/index.php?tema=19](http://govt-urls.usa.gov/tematres/vocab/index.php?tema=19)\n\n2. Your task is to visit the website for each MD city, county, and state agency.\n\n3. Review the website to make sure it still belongs to an official government agency, and add a scope note to provide some basic bibliographic information about the agency.\n\n4. If you want to try this out but can’t tackle all the links, let us know! We still want to hear from you!\n\nIf there is a another state you prefer to work on let us know.  Chances are it is still available.\n\nPerfect for librarians, catalogers, or those who want to take a virtual tour of the Mount Rushmore state.\n\n**Duration** : 2-4 hours **Deadline** : 2 weeks after the task is assigned"
+  },
+  {
+    "createdAt": "2014-03-04T16:05:47+00:00",
+    "name": "help-us-develop-government-wide-open-content-models-2",
+    "title": "Help us Develop Government-Wide Open Content Models",
+    "state": "completed",
+    "description": "**20%er:** Content models define the structure of information products and their constituent content components. Developing shared and open content models enable content producers to make their content  [more adaptive and shareable](http://www.howto.gov/web-content/technology/content-management-systems/how-to-create-open-structured-content) and “future-ready.”\\n\\n\n\nThe Digital Services Innovation Center has sponsored a working group that has created 2 shared content models for \"articles\" and \"events\" for use in the federal government. We would like to socialize the current models and create more. The proper candidate(s) will help us complete the following deliverables to increase the expertise around and use of shared and open content models in the federal government.\n\n- Assist the Innovation Center in the facilitation of the open content model working group\n- Research & document existing private sector content modeling types and other relevant practices to tie them to current and future models\n- Identify other potential popular/relevant government content models\n- Coordinate creation of at least 1 government-wide content model with working group and other interested individuals\n- Coordinate and assist socialization of working group efforts as well as current and future content models. This would include blog posts, webinars and other speaking engagements\n- Create ongoing community/network around content modeling in order to set up ability/environment to create other relevant government wide content models\n**Duration** : 6 months **Deadline** : Ongoing"
+  },
+  {
+    "createdAt": "2014-03-11T17:36:09+00:00",
+    "name": "let-your-inner-data-detective-out-and-get-to-know-ohio",
+    "title": "Let Your Inner Data Detective out and Get to Know Ohio",
+    "state": "completed",
+    "description": "**Tapas**: USA.gov searches across all federal, state, and local government websites–that’s hundreds of billions of pages from .gov and .mil websites plus  [over 11,000 .com, .org, etc. websites](http://govt-urls.usa.gov/tematres).\n\n \\n\\n\n\nHere’s your chance to improve the results searchers on USA.gov see for the state of Ohio.\n\n1. Once you let us know that you’re interested, we’ll give you access to edit the known Ohio websites directly.\n\n2. Your task is to visit the website for each OH city, county, and state agency.\n\n3. Review the website to make sure it still belongs to an official government agency, and add a scope note to provide some basic bibliographic information about the agency.\n\n4. If you want to try this out but can’t tackle all the links, let us know! We still want to hear from you!\n\nIf there is a another state you prefer to work on let us know.  Chances are it is still available.\n\nPerfect for librarians, catalogers, or those who want to take a virtual tour of the Mount Rushmore state."
+  },
+  {
+    "createdAt": "2014-03-20T03:02:09+00:00",
+    "name": "develop-a-toolkit-on-how-to-write-a-great-open-opportunities-task",
+    "title": "Develop a checklist on how to write a great Open Opportunities task",
+    "state": "completed",
+    "description": "**Tapas**: The Open Opportunities team is looking for someone to develop a checklist or guide to help task creators write good tasks to post on the Open Opportunities platform.\n\nOne of the things we’ve learned is that creating good tasks is difficult for many people. \"Chunking\" work into simple and manageable tasks with concrete deliverables is a culture shift requiring people to change the way they look at work.\n\nDuring the pilot we collected lessons and tips as to what makes a good task. Now, we need someone to come in and take that information and turn it into an easy to use guide, checklist or a combination of the two that will help provide direction to task creators.\n\n**Duration:**  4-8  hours\n\n**Deadline** : May 1"
+  },
+  {
+    "createdAt": "2014-03-20T03:12:11+00:00",
+    "name": "caption-2-short-videos-about-the-open-opportunities-program",
+    "title": "Caption 2 short videos",
+    "state": "completed",
+    "description": "**Tapas:**: Open Opportunities recently produced 2 short videos about the experiences of our participants. Before we can share the videos of the great work our innovators are doing we need someone to caption them.\n\nCaptioning can be done in YouTube using their automatic pause feature.\n\n\\n\\nOne video is approximately 2 minutes and the other is one minute 14 seconds.\n\n**Duration** : Up to 2 hours **Deadline:** One week after task is accepted."
+  },
+  {
+    "createdAt": "2014-03-27T01:02:46+00:00",
+    "name": "planner-extraordinaire-for-the-may-open-opportunities-tapathon",
+    "title": "Planner Extraordinaire for the May Tapathon",
+    "state": "completed",
+    "description": "**Tapas:** The Open Opportunities team is planning their second Tapathon for early May 2014 and is looking for someone to to plan and oversee the event. The Tapathon is a chance for the entire Open Opportunities community to get together for an afternoon of networking, completing tapas tasks and fun.\n\n\\n\\nOur first Tapathon which was held in September was a great success and we captured the processes which will make planning and organizing a breeze.As our event planner extraordinaire you will work with the Open Opportunities core team to:\n\n- Design the Tapathon\n- Plan and draft the agenda\n- Oversee logistics\n- Coordinate event activities (e.g. get to know you games, refreshments)\n- Prepare invitations to send to potential attendees\n- Keep track of attendees and let us know of the status\n- Ensure the day of the event runs smoothly\n- Design and implement program evaluation\n**Duration** : 16 -24 hours **Deadline** : Mid - May"
+  },
+  {
+    "createdAt": "2014-03-27T01:03:12+00:00",
+    "name": "innovations-in-apis-guest-blogger-for-digital-gov-platform",
+    "title": "Innovations in APIs: Guest Blogger for Digital Gov Platform",
+    "state": "completed",
+    "description": "******20%**: In order to open up data for developer use, agencies are implementing APIs. This position makes you a writer for the code channel of the  [DigitalGov](http://www.digitalgov.gov/) platform which focuses on ways agencies are releasing APIs and using code for their digital efforts. Once a week we will feature a post on an API an agency has implemented or _other useful information_. Posts should be composed in less than an hour to help keep focus on simplicity and speed.\n\\n\\nThere are a couple ways we can help you get ideas for articles: We can provide you with a link to federal APIs or you can search for API's to feature. Each post should include:\n- A link to the API\n- Explanation on why it was implemented\n- A link to creating API resource(s) on the DigitalGov platform\n\nIn addition to writing about specific agency APIs there is a robust API Google Group that you can join that has discussions that can be used for articles as well. ** **\n\n**Duration** : This task will take the volunteer up to 2 hours per week for 6 months. We are looking for you to write at least 3-4 posts a month.\n\n**Deadline** : September 30, 2014"
+  },
+  {
+    "createdAt": "2014-04-03T14:47:40+00:00",
+    "name": "content-marketing-guru",
+    "title": "Content Marketing Guru",
+    "state": "completed",
+    "description": "**20%er:**  We are looking for a Content Marketing Guru to collaborate with the Open Opportunities team and help us spread the word and grow our network.\\n\\n\n\nWork will include:\n- \n\nHelping review and revitalize our communications and outreach strategy\n\n- \n\nDeveloping content for our weekly newsletter, blog, LinkedIn, Facebook, Twitter etc…\n\n- \n\nGetting the word out\n\n- \n\nAttending periodic team meetings and coordinating with the team as needed (we will be flexible based on your availability)\n\nIf you are a communicator or storyteller this opportunity is for you. You will be working on a cutting edge cross-governmental program.\n\n**Duration** : 20% of the innovator’s time for 3 – 6 months **Deadline** : Ongoing (to be negotiated)"
+  },
+  {
+    "createdAt": "2014-04-03T13:25:32+00:00",
+    "name": "help-us-tell-govconnects-history",
+    "title": "Document the history of GovConnect as it unfolds (through various media)",
+    "state": "completed",
+    "description": "**20%:** GovConnect is looking for a knowledge manager/information curator to become part of the team.  The lucky candidate will collect stories, interviews, and photographs to keep track of the history of GovConnect including events and experiences.\\n\\n\n\nIf you believe that our government must adapt to better address 21st century challenges and to attract the talent we'll need to remain an employer of choice for our nation’s best, we're off to a good start!\n\nHere are some of the things you may be asked to do if you agree to take on the task.\n\n- Attend GovConnect events\n- \n\nUse online tools for storytelling and information display (like Padlet, mural.ly, and Pinterest)\n\n- \n\nBe comfortable with basic interview techniques (or open to learning!)\n\n- \n\nEnjoy writing in a creative way– we’re looking for a case study\n\n- \n\nLike taking pictures and curating slide shows and other photo displays\n\n- \n\nDon't mind bugging people when they need to get you information\n\n- \n\nKnow a good quote when you hear it – “That was fantastic – can I quote you on that?”\n\n- \n\nCan decide the most effective medium to tell the story (for ex, words, pictures, video)\n\n- \n\nWants to convey the impact of those stories\n\nDon't worry if not all of these things are up your alley.  GovConnect is a team effort and we will work with you.\n\nWhat do we expect to get from this participation? Maybe an interactive presentation (don’t worry you can work with our graphic designer on that), “case study documents”,  or audio recordings, etc\n\n**Background** : GovConnect is an initiative of the President’s Second Term Management Agenda seeking to build a more agile, collaborative and innovative workforce for the 21st century.  We all know that the nature of work is changing – more dynamic, less hierarchical, more project-based, and that the workforce is changing, too.  On top of it all, the challenges facing government defy organizational silos and job descriptions, but they way we are set up to solve problems – how we’re structured and how our job descriptions are written - isn’t necessarily “ahead of the curve.”  This is an exciting project that will be running workforce agility pilots at a number of agencies, using design thinking to address challenges in new and different ways, and pairing agencies interested in solving problems differently with mentors from previous and successful experiments in a more agile workforce. OPM and EPA are leading the project, working closely with partners at the White House, GSA, the State Department, and HUD.\n\n**Are you in? **\n\n**Duration:** 6 months"
+  },
+  {
+    "createdAt": "2014-04-02T17:22:39+00:00",
+    "name": "become-a-mobile-code-miner",
+    "title": "Become A Mobile Code Miner",
+    "state": "completed",
+    "description": "**Tapas:** Federal agencies can use the the federal  [Mobile Code Catalog](http://gsa.github.io/Mobile-Code-Catalog) to help them make content and services available anytime, anywhere, and from any device. Here **,**  agencies can access whole  [frameworks for a mobile web site](http://gsa.github.io/Mobile-Code-Catalog/web_html.html), modular code to solve common problems, or  [even links to complete apps](https://github.com/whitehouse/wh-app-ios) to use as a template for their own apps.\\n\\n\n\nWe need a code miner to help us find other mobile code out there for agencies to use. Your job will be to search Github and other agency resources to find mobile code that agencies can leverage to improve the mobile experience for their users.\n\n**Duration:** 8 hrs to be completed over 4 weeks (you will check in with us once a week on progress) **Deadline** : Negotiable"
+  },
+  {
+    "createdAt": "2014-04-04T20:08:04+00:00",
+    "name": "help-us-market-government-wide-open-content-models",
+    "title": "Help us Market Government-Wide Open Content Models",
+    "state": "completed",
+    "description": "**Tapas:** Help get the word out about 2 shared content models developed for government use. Content models define the structure of information products and their constituent content components. Developing shared and open content models enable content producers to make their  [content more adaptive and shareable and “future-ready](https://www.digitalgov.gov/2013/07/29/how-to-create-open-structured-content/).” Candidates will help us compose articles, tweets and brainstorm other marketing approaches  adoption for these models. **Duration:** 1-3 hours depending on task **Deadline:** Ongoing"
+  },
+  {
+    "createdAt": "2014-04-08T19:51:43+00:00",
+    "name": "knowledge-manager-for-federal-wide-digital-engagement",
+    "title": "Knowledge Manager for Federal-wide Digital Engagement",
+    "state": "completed",
+    "description": "**20%:** The Federal Social Media Community of Practice, or SocialGov Community, needs a Knowledge Manager who is part Stephen Wolfram and part Indiana Jones who can help research, analyze and report trends in the federal-wide social media community. We need you to join our team and work side-by-side with us to help build the government of the 21st Century.\\n\\n\n\nActivities include:\n\n- Identifying common themes and frequent challenges across agencies.\n- Curating and sharing information that will be helpful to the community at large.\n- Sharing resources and solutions that will reduce duplications of efforts.\n- Writing blog posts for DigitalGov.gov based on hot topics from the SocialGov listserve.\n- Communicating with knowledge managers at individual agencies and recruiting new agencies to join the community.\n- Contributing to ongoing projects including the Performance Analysis Toolkit and Social Media Policy Development Working Group.\n- Hosting webinars for the DigitalGov Community.\n\nOur Knowledge Manager will operate on the forefront of emerging technology, policy and development, and as a result must live by the words of Polar explorer Robert Peary, “We will find a way or make one.”\n\n**Background:** The SocialGov Community includes more than 600 managers from over 130 federal agencies, working together to create shared solutions that use digital engagement and data to measurably improve citizen services and reduce costs. It is managed by GSA’s Office of Citizen Services and Innovative Technologies, and partners with MobileGov, User Experience, Open Data, Prizes and Competitions and other DigitalGov communities.\n\n** Duration: ** 20% of the innovator’s time for 3 – 6 months **Deadline:** Ongoing (to be negotiated)"
+  },
+  {
+    "createdAt": "2014-04-10T00:36:03+00:00",
+    "name": "mobile-app-icon-url-hunter",
+    "title": "Mobile App Icon URL Hunter",
+    "state": "completed",
+    "description": "**Tapas: **Help us improve the [USA.gov Apps Gallery](http://apps.usa.gov/)!\n\nWe need a few good folks to help us update the Federal Mobile Apps Registry API by finding the icon URL of 20 mobile apps located in the USA.gov Apps Gallery. Here's how it will work:\\n\\n\n\n- \n\nWe’ll provide you with a list of 20 government apps and their iOS’ App store and/or Google play URLs for which we need the icon URL\n\n- \n\nYou will locate the icon URL of the 20 app's on iOS’ App store and/or Google play and copy the icon URL onto the list.\n\n- \n\nYou will have completed the task when you send the completed spreadsheet with the 20 app icon URL's back to us.\n\nThe data you provide will help us improve the next iteration of the USA.gov Apps Gallery.\n\n**Duration:** 1-2 hours\n\n**Deadline:** Task should be completed within two weeks of us providing you with the spreadsheet."
+  },
+  {
+    "createdAt": "2014-04-10T15:53:47+00:00",
+    "name": "update-a-few-documents-for-open-opportunities",
+    "title": "Update a FEW documents for Open Opportunities",
+    "state": "completed",
+    "description": "**Tapas: **The Open Opportunities program has grown a lot in the past year and there are a few documents available online that need to be updated. It's a very simple task that when completed will make the Open Opportunities team do the \"Happy\" dance!\\n\\nIf you want to work with the Open Opportunities team and learn more about what we do, this is a great opportunity. You will have access to our marketing materials and presentations so maybe, just maybe those things will be helpful to you for the work that you're doing in your agency. As you might know, we're all about sharing our resources with our network. **Are you in? **** Duration:  **up to 2 hours** Deadline: **2 weeks after accepting"
+  },
+  {
+    "createdAt": "2014-04-24T02:52:28+00:00",
+    "name": "create-a-video-on-how-to-write-a-great-open-opportunities-task",
+    "title": "Be a producer for an upcoming video on how to write great Open Opportunities tasks",
+    "state": "completed",
+    "description": "**Tapas**: The Open Opportunities team is looking for someone to oversee the development of a video to help task creators write good tasks to post on the platform.\n\n\\n\\n\n\nOne of the things we’ve learned is that creating good tasks is difficult for many people. \"Chunking\" work into simple and manageable tasks with concrete deliverables is a culture shift requiring people to change the way they look at work.\n\nDuring the pilot we collected lessons and tips as to what makes a good task. Now, we need someone to oversee the development of a video that will provide clear direction to task creators.\n\nIf needed, you will have support from our office videographer who can help with story boarding, filming and editing.\n\nInterested? Press the blue button to learn more.\n\n**Duration:**  4 -8 hours\n\n**Deadline** : May 22"
+  },
+  {
+    "createdAt": "2014-04-23T14:34:06+00:00",
+    "name": "let-your-inner-data-detective-out-and-get-to-know-virginia-or-your-favorite-state",
+    "title": "Let Your Inner Data Detective out and Get to Know Virginia (or your favorite state)",
+    "state": "completed",
+    "description": "**Tapas**: USA.gov searches across all federal, state, and local government websites–that’s hundreds of billions of pages from .gov and .mil websites plus  [over 11,000 .com, .org, etc. websites](http://govt-urls.usa.gov/tematres).\n\n\\n\\nHere’s your chance to improve the results searchers on USA.gov see for the state of Virginia.\n\n1. Once you let us know that you’re interested, we’ll give you access to edit the known Virginia websites directly:  [http://govt-urls.usa.gov/tematres/vocab/index.php?tema=156](http://govt-urls.usa.gov/tematres/vocab/index.php?tema=156)\n\n2. Your task is to visit the website for each VA city, county, and state agency.\n\n3. Review the website to make sure it still belongs to an official government agency, and add a scope note to provide some basic bibliographic information about the agency.\n\n4. If you want to try this out but can’t tackle all the links, let us know! We still want to hear from you!\n\nIf there is a another state you prefer to work on let us know.  Chances are it is still available.\n\nPerfect for librarians, catalogers, or those who want to take a virtual tour.\n\n**Duration** : 2-4 hours **Deadline** : 2 weeks after the task is assigned"
+  },
+  {
+    "createdAt": "2014-04-23T14:34:53+00:00",
+    "name": "dataspreadsheet-consolidation-for-digitalgov-university-webinars",
+    "title": "Spreadsheet Merge for DigitalGov University Webinars",
+    "state": "completed",
+    "description": "**Tapas:** Do you have a passion for organization, consolidation and integration? Then this task is for you.  We are looking for someone to take our event information collection spreadsheets and combine the information into one spreadsheet.  \\n\\n\n\nWe aren’t looking for formatting, analyzing or cleaning up of the data - just combining. You will be given the spreadsheets for all the webinar events and your job will be to merge them together into one spreadsheet.\n\n**Background:** [DigitalGov University](http://www.digitalgov.gov/digitalgov-university/) (DGU) is the federal government’s training program for digital media and citizen engagement.\n\n**Duration:** up to 4 hours **Deadline:** 2 weeks after accepting"
+  },
+  {
+    "createdAt": "2014-04-23T14:34:28+00:00",
+    "name": "dataspreadsheet-consolidation-for-digitalgov-university-in-person-events",
+    "title": "Spreadsheet Merge for DigitalGov University In-person Events",
+    "state": "completed",
+    "description": "**Tapas:** Do you have a passion for organization, consolidation and integration? Then this task is for you.  We are looking for someone to take our event information collection spreadsheets and combine the information into one spreadsheet.\\n\\n\n\nWe aren’t looking for formatting, analyzing or cleaning up of the data - just combining. You will be given the spreadsheets for all in-person training events and your job will be to merge them together into one spreadsheet.\n\n**Background:**   [DigitalGov University](http://www.digitalgov.gov/digitalgov-university/) (DGU) is the federal government’s training program for digital media and citizen engagement.\n\n**Duration:** up to 4 hours **Deadline:** 2 weeks after accepting"
+  },
+  {
+    "createdAt": "2014-04-24T17:08:04+00:00",
+    "name": "develop-a-readiness-checklist-sites-usa-gov",
+    "title": "Develop a sites.usa.gov Readiness Checklist",
+    "state": "completed",
+    "description": "**Tapas:** [Sites.usa.gov](http://sites.usa.gov/) provides agencies with WordPress as a content management tool. The sites team is looking for someone to help develop a checklist that will help agencies jump start their preparation to using [sites.usa.gov](sites.usa.gov).\\n\\n\n\nProblem: The sites team is delivering WordPress instances to customers, but they often go live slowly, or not at all, because the customer was not adequately prepared. We need someone who can pull together a checklist based on materials that we already have with those “things”/factors (no more than 20 “things”!) that need to be considered before implementing a site. If you have implemented a website (preferably with a CMS) or have knowledge of, or interest in, learning more about WordPress this task is for you.\n\n**Background:** The checklist will be shared with to potential customers after a kick off call. Our goal is to have:\n1. \n\nmore WordPress instances going live\n\n2. \n\nmore sites using the sites.usa.gov program, and\n\n3. \n\nmore federal websites managing their content in WordPress\n\nIf you want to learn more, the   [sites.usa.gov](http://sites.usa.gov/) team can share our standard powerpoint presentation, and there is plenty of information on the site itself ( [sites.usa.gov](http://sites.usa.gov/)). The sites team will also answer any questions you have via email at [sitessupport@gsa.gov](mailto:sitessupport@gsa.gov)._ **Are you in** _? Want to help your federal colleagues, and be posted for bragging rights on sites.usa.gov?  Then _ **push the blue button** _. **Duration:** 2-4 hours **Deadline:** Two weeks after accepting the task"
+  },
+  {
+    "createdAt": "2014-04-24T13:40:19+00:00",
+    "name": "be-an-event-coordinator-for-one-day",
+    "title": "Be an event coordinator for one day",
+    "state": "completed",
+    "description": "**Tapas:** The Open Opportunities team is planning their second Tapathon for early 2015 and is looking for someone to help us keep things organized during the event. The Tapathon is a chance for the entire Open Opportunities community to get together for an afternoon of networking, completing tapas tasks and fun.\\n\\n\n\nOur first Tapathon which was held in September 2013 was a great success.  As our event coordinator for the day you will work with the Open Opportunities core team to:\n\n- \n\nOversee logistics\n\n- \n\nCoordinate event activities (e.g. get to know you games, refreshments)\n\n- Ensure the day of the event runs smoothly\n**Duration:** 4-8 hours (Tapathon will last approximately 3 hours with an hour or two prep) **Deadline:** Event to be held in early 2015"
+  },
+  {
+    "createdAt": "2014-04-24T13:48:18+00:00",
+    "name": "help-us-plan-our-2nd-tapathon",
+    "title": "Help us plan our next Open Opportunities tapathon",
+    "state": "completed",
+    "description": "**Tapas:** The Open Opportunities team is planning their next get together or \"Tapathon\"  for early 2015. We are looking for one or two people to help us plan this cool event. The Tapathon is a chance for the entire Open Opportunities community to get together for an afternoon of networking, completing tapas tasks and fun.\\n\\n\n\nOur first Tapathon was held in September 13 so we have a lot of things already in place which will make planning and organizing a breeze. As our event planner extraordinaire you will work with the Open Opportunities core team to:\n\n- \n\nPlan and draft the agenda\n\n- \n\nPrepare invitations to send to attendees\n\n- \n\nDesign and implement a survey\n\n- \n\nKeep track of attendees and let us know the status of RSVPs\n\n**Duration:** 8-16 hours\n\n**Deadline:**  Mid-January - Early February"
+  },
+  {
+    "createdAt": "2014-04-25T20:46:42+00:00",
+    "name": "knowledge-manager-for-military-digital-engagement",
+    "title": "Knowledge Manager for Digital Engagement",
+    "state": "completed",
+    "description": "**20%:** The Federal Social Media Community of Practice, or SocialGov Community, needs a Knowledge Manager who is part Stephen Wolfram and part Indiana Jones who can help research, analyze and report trends in the federal-wide social media community. We need you to join our team and work side-by-side with us to help build the government of the 21st Century. ![](https://gsablogs.gsa.gov/dsic/wp-includes/js/tinymce/plugins/wordpress/img/trans.gif \"More...\")\\n\\n\n\nActivities include:\n\n- \n\nResearching, analyzing and reporting trends in emerging engagement technology\n\n- \n\nCurating data from agencies across government and international stakeholders\n\n- \n\nDistribute a weekly Knowledge Digest that compiles trends, news and information\n\n- Working closely with your counterpart on the civilian side\n\nOur Knowledge Manager will operate on the forefront of emerging technology, policy and development, and as a result must live by the words of Polar explorer Robert Peary, “We will find a way or make one.”\n\n**Background:**  The SocialGov Community includes more than 600 managers from over 130 federal agencies, working together to create shared solutions that use digital engagement and data to measurably improve citizen services and reduce costs. It is managed by GSA’s Office of Citizen Services and Innovative Technologies, and partners with MobileGov, User Experience, Open Data, Prizes and Competitions and other DigitalGov communities.\n\n** Duration: ** 20% of the innovator’s time for 3 – 6 months **Deadline: ** Ongoing (to be negotiated)"
+  },
+  {
+    "createdAt": "2014-04-28T20:15:05+00:00",
+    "name": "create-github-space-for-government-wide-open-content-models",
+    "title": "Create GitHub Space for Government-Wide Open Content Models",
+    "state": "completed",
+    "description": "**20%:** Content models define the structure of information products and their constituent content components. Developing shared and open content models enable content producers to make their content  [more adaptive and shareable](http://www.howto.gov/web-content/technology/content-management-systems/how-to-create-open-structured-content) and “future-ready.”\\n\\n\n\nThe Digital Services Innovation Center has sponsored a working group that has created 2 sharedcontent models for \"articles\" and \"events\" for use in the federal government. The working group has decided to host these models, their discussion and future content models in GitHub. We are looking for someone to help us plan and then program these models in GitHub.\n\nThe proper candidate(s) will help us complete the following deliverables to increase the expertise around and use of shared and open content models in the federal government.\n\n- Participate as member of the working group, contributing to the content model discussions, and helping to publicize the work of the group.\n- Research existing GitHub practices in Government for best implementation\n- Educate working group about GitHub platform and options\n- Help plan content model working group implementation of GitHub that includes content models, look and feel, discussion space, etc.\n- Implement working group GitHub space- create look and feel, upload content models and create discussion space.\n- Assist monitoring of implemented GitHub space and assist efforts to educate and socialize content models on GitHub\n**Duration** : 3-4 Months (up to 8 hours a week) **Deadline** : Early May"
+  },
+  {
+    "createdAt": "2014-04-30T16:56:36+00:00",
+    "name": "feed-the-beast-mobile-code-sharing-catalog-code-snippets-uploader",
+    "title": "Feed the Beast: Mobile Code Sharing Catalog Code Snippets Uploader",
+    "state": "completed",
+    "description": "**Tapas:** Federal agencies can use the federal  [Mobile Code Catalog](http://gsa.github.io/Mobile-Code-Catalog) to help them make content and services available anytime, anywhere, and from any device. Here **,**  agencies can access whole  [frameworks for a mobile web site](http://gsa.github.io/Mobile-Code-Catalog/web_html.html), modular code to solve common problems, or  [even links to complete apps](https://github.com/whitehouse/wh-app-ios) to use as a template for their own apps.\\n\\nWe have a number of mobile code snippets to fork into the catalog. You will help us determine where up to 3 code snippets should go on the catalog and then submit the changes via pull request from your GitHub account. This is a great task for someone who wants to learn about new mobile code and/or hone/develop their GitHub chops. **Duration:**  1-3 hrs depending on your GitHub expertise **Deadline** : May 23rd"
+  },
+  {
+    "createdAt": "2014-04-30T16:56:14+00:00",
+    "name": "give-the-mobile-code-sharing-catalog-a-makeover",
+    "title": "Swap logo and change color of a web page",
+    "state": "completed",
+    "description": "**Tapas:** We need someone to add a new logo (we'll provide that!) and change the color scheme (we'll provide that too!) of the [mobile code sharing catalog](http://gsa.github.io/Mobile-Code-Catalog/) to match [DigitalGov](http://digitalgov.gov).  You will make these changes via pull request from your GitHub account where we will accept the changes. This is a great task for someone with a good design eye who wants to develop their GitHub chops. If you're not familiar with GitHub, we'll help you out.\\n\\n **Background: ** Federal agencies can use the the federal  [Mobile Code Catalog](http://gsa.github.io/Mobile-Code-Catalog) to help them make content and services available anytime, anywhere, and from any device. Here **,**  agencies can access whole  [frameworks for a mobile web site](http://gsa.github.io/Mobile-Code-Catalog/web_html.html), modular code to solve common problems, or  [even links to complete apps](https://github.com/whitehouse/wh-app-ios) to use as a template for their own apps.\n\n**Duration:**  2-4 hrs depending on your GitHub expertise **Deadline** : May 23rd"
+  },
+  {
+    "createdAt": "2014-04-29T00:07:33+00:00",
+    "name": "6150",
+    "title": "Help Update our Open Opps Power Point & Create a Couple New Graphs",
+    "state": "completed",
+    "description": "**Tapas:** The Open Opportunities program is looking for someone to who can help us create a new PowerPoint Presentation using existing presentations and creating a few new slides with new data. The purpose of the presentation is to tell the open opportunities story.   \\n\\n                                                                                                                                                                We will help you decide which slides to reuse and will provide all the data you need to create the new graphs.  You may also use your creative juices to improve current images and graphics.\n\n**Duration:** A few days\n\n**Deadline:** 04/25/2014"
+  },
+  {
+    "createdAt": "2014-05-15T13:25:44+00:00",
+    "name": "design-a-one-year-badge-for-the-open-opps-wall-of-fame",
+    "title": "Design a \"One Year\" Badge for the Open Opps Wall of Fame",
+    "state": "completed",
+    "description": "**Tapas:** We need someone to design a badge to give special recognition the Open Opportunity innovators who have work with us for a for a year or more. Please design and send us a badge adhering to a look and feel similar to the already existing Tapas & 20% badges currently on the Wall of Fame. ( [http://gsablogs.gsa.gov/dsic/category/wall-of-fame](http://gsablogs.gsa.gov/dsic/category/wall-of-fame)).\\n\\n **Duration:** Up to 2 hours **Deadline:** One week after accepting the task"
+  },
+  {
+    "createdAt": "2014-05-13T16:27:56+00:00",
+    "name": "developing-and-running-an-open-user-group-for-dap-google-analytics-2",
+    "title": "Running an open user group for DAP Google Analytics - 2",
+    "state": "completed",
+    "description": "**20%**: The user group would be open to any government employee to attend (to learn more about GA etc.), although the scope will be focused on Google Analytics and using it as part of DAP. We already have 30 participating agencies, more than 3000 websites, and nearly 1200 individual users using DAP GA. So this user group would definitely be beneficial to support knowledge sharing, reporting tips and strategies, analysis topics etc. The format of the user group would be a monthly Webinar/phone conference. The content for each month would be led and coordinated by the volunteer, and task creator would attend the calls/Webinars to help answer questions, help with presentations etc. **Deadline** : Ongoing **Duration:**  6 months from accepting task"
+  },
+  {
+    "createdAt": "2014-05-13T19:56:50+00:00",
+    "name": "tell-feds-what-structured-content-can-do-for-them",
+    "title": "Tell Feds What Structured Content Can Do For Them",
+    "state": "completed",
+    "description": "**Tapas**: Make your presence at our webinar count triple! If you’re joining us for the first webinar in our series “ [What Structured Content Can Do For You](https://www.digitalgov.gov/event/what-structured-content-can-do-for-you-article-model/)” help us reach more feds by writing a recap that we can share with the extended DigitalGov community.\\n\\n\n\nYou’ll be an active participant as the official reporter on the scene and allow us to give play by play details of this groundbreaking event. You’ll be taking notes live during the webinar but will have backstage access to the recording, the presenters and their notes afterwards to write your wrap up in plain language. Your report will be featured with your byline on [DigitalGov](http://www.digitalgov.gov/) for the world to see and you will get a cool new press badge on our [Wall of Fame.](http://gsablogs.gsa.gov/dsic/category/wall-of-fame/) **Deadline:** May 21, 2014 **Duration** : 2-4 hours"
+  },
+  {
+    "createdAt": "2014-05-15T13:23:23+00:00",
+    "name": "needed-usability-sherlock-to-find-and-create-case-studies-of-digital-products",
+    "title": "Needed: Usability “Sherlock” to find and create case studies of digital products",
+    "state": "completed",
+    "description": "**20%**:  We need a good \"content scout\" to help us expand our successful [Usability Case Study section](http://go.usa.gov/8qeH). We need the right person to find newly launched or redesigning systems - websites, mobile apps, databases, etc. - and find out how user experience helped make them great.\\n\\nStories will be posted in our [Usability Case Study gallery](http://www.digitalgov.gov/resources/digitalgov-user-experience-program/government-usability-case-studies/) to help educate federal employees about User Experience. **Specifically, this person will:**\n- Look on [digitalgov.gov](http://www.digitalgov.gov/), federal IT publications, social media, listservs, and elsewhere for good candidates\n- Ask agencies if they’d be willing to be featured in our section\n- Get them to either submit it themselves, or interview them\n- Edit / write usability case study, combining text with screenshots to tell the story of how user experience and customer research made the product better\n- Submit usability case study to [digitalgov.gov](http://www.digitalgov.gov/) for publication\n**Skills needed:**\n- Writing / editing\n- Wordpress basics (or willingness to learn)\n- Basic tech skills (Google Apps)\n- Willingness to interview candidate\n- Optional: Basic social media skills (twitter, etc.)\n**Deadline:** Ongoing **Duration:** 3-6 months"
+  },
+  {
+    "createdAt": "2014-05-15T13:24:51+00:00",
+    "name": "design-a-reporters-badge-for-the-open-opps-wall-of-fame",
+    "title": "Design a \"Reporters\" Badge for the Open Opps Wall of Fame",
+    "state": "completed",
+    "description": "**Tapas:** We need someone to design a badge to recognize our Open Opps \"reporters\" who take notes and recap [DigitalGov University](http://www.digitalgov.gov/?s=digitalgov+university) webinars. \\n\\nPlease design and send us a badge adhering to a look and feel similar to the already existing badges currently on the [Wall of Fame](http://gsablogs.gsa.gov/dsic/category/wall-of-fame/). ( [http://gsablogs.gsa.gov/dsic/category/wall-of-fame](http://gsablogs.gsa.gov/dsic/category/wall-of-fame)). **Duration: ** Up to 2 hours **Deadline: ** One week after accepting the task"
+  },
+  {
+    "createdAt": "2014-05-19T16:17:56+00:00",
+    "name": "create-a-conference-app-for-the-sec",
+    "title": "Create a Conference App for the SEC",
+    "state": "completed",
+    "description": "**Tapas:** The Securities and Exchange Commission is looking for someone to create an internal conference app for their agency's upcoming 1st Annual Budget and Performance Summit, offered to SEC employees nationwide. For 3 days, agency staff will participate in training and attend panel discussions on budget and performance-related topics.\\n\\n\n\nThe SEC wants to provide an app to attendees that will make the summit more exciting and useful by allowing the organizers to digitally and instantly communicate with and provide resources to attendees. We would like to app to contain features such as the summit schedule, speaker bios, attendee listing (showing the name and email of summit attendees so that they can easily connect with one another), conference document/presentation library, and a News link where we can provide instant updates. Bonus features would include the ability for attendees to develop a customize schedule, a polling feature, and push notifications. The app should be viewable on Apple and Android devices, however Blackberry is preferred. We should be able to access the app only via our agency network, so it does not need to be mobile, but mobile is preferred. The development of this app could change internal agency conferences government-wide! **Deadline:** June 12, 2014 **Duration:** 24-40 hours"
+  },
+  {
+    "createdAt": "2014-05-21T14:34:20+00:00",
+    "name": "make-an-important-flowchart-into-a-super-fly-chart",
+    "title": "Make an important flowchart into a \"super-fly chart\"!",
+    "state": "completed",
+    "description": "**Tapas:** A few weeks ago we wrote a [blog post](https://www.digitalgov.gov/2014/05/13/what-is-a-terms-of-service-and-how-do-i-get-one/) about how to get a Terms of Service for online tools and apps. That's really important, because it lets government use the most current and powerful services out there, without the risk of legal issues. We also created a [graphic](http://www.digitalgov.gov/files/2014/05/1177-x-2034-full-size-TOS-Terms-of-Service-flowchart-graphic.jpg) explaining the process.\\n\\nIt's kind of boring, we admit. But we need to get this information out there to answer the constant questions we get. Can you make this graphic better, more interesting, more visual? As long as we keep very close to the wording (which was prepared by our lawyers), you can go crazy with the design. Thanks for helping to make government more effective and more beautiful! **Deadline** : 2 weeks after accepting the task **Duration** : 2 - 4 hours"
+  },
+  {
+    "createdAt": "2014-05-28T14:23:00+00:00",
+    "name": "recap-the-digitalgov-citizen-services-summit-performance-analysis-panel",
+    "title": "Recap the DigitalGov Citizen Services Summit Performance Analysis Panel",
+    "state": "completed",
+    "description": "**Tapas**: Make your presence at the [DigitalGov Summit](http://www.digitalgov.gov/event/digitalgov-citizen-services-summit/) count! Since you've already signed up and we know you'll be taking copious notes, help us reach more feds by signing up to write a short recap of the Performance Analysis Panel so we can share with the extended DigitalGov community.\\n\\nThe recap does not need to be more than a couple paragraphs and focus should be on the 3-5 key takeaways from each session. This is your opportunity to be an official reporter on the scene of this groundbreaking event. You’ll be taking notes live during the session and your report will be used as part of an overall event summary to be published on [DigitalGov](http://www.digitalgov.gov/) for the world to see, and you will get a badge on the [Open Opportunities](http://gsablogs.gsa.gov/dsic/category/open-opportunities/) our [Wall of Fame](http://gsablogs.gsa.gov/dsic/category/wall-of-fame/). Panel summaries will be assigned on a first come first served basis.\n\n**Deadline:** COB June 2\n\n**Duration:** Up to 2 hours"
+  },
+  {
+    "createdAt": "2014-05-28T14:24:10+00:00",
+    "name": "recap-the-digitalgov-cx-summit-customer-experience-across-channels-panel",
+    "title": "Recap the DigitalGov Citizen Services Summit Customer Experience Across Channels Panel",
+    "state": "completed",
+    "description": "**Tapas**: Make your presence at the [DigitalGov Summit](http://www.digitalgov.gov/event/digitalgov-citizen-services-summit/) count! Since you've already signed up and we know you'll be taking copious notes, help us reach more feds by signing up to write a short recap of the Customer Experience Across Channels Panel so we can share with the extended DigitalGov community.\\n\\nThe recap does not need to be more than a couple paragraphs and focus should be on the 3-5 key takeaways from each session. This is your opportunity to be an official reporter on the scene of this groundbreaking event. You’ll be taking notes live during the session and your report will be used as part of an overall event summary to be published on [DigitalGov](http://www.digitalgov.gov/) for the world to see, and you will get a badge on the [Open Opportunities](http://gsablogs.gsa.gov/dsic/category/open-opportunities/) our [Wall of Fame](http://gsablogs.gsa.gov/dsic/category/wall-of-fame/). Panel summaries will be assigned on a first come first served basis.\n\n**Deadline:** COB June 2\n\n**Duration:** Up to 2 hours"
+  },
+  {
+    "createdAt": "2014-05-28T14:35:44+00:00",
+    "name": "recap-the-digitalgov-citizen-services-summit-public-private-partnerships-panel",
+    "title": "Recap the DigitalGov Citizen Services Summit Public Private Partnerships Panel",
+    "state": "completed",
+    "description": "**Tapas**: Make your presence at the  [DigitalGov Summit](http://www.digitalgov.gov/event/digitalgov-citizen-services-summit/) count! Since you've already signed up and we know you'll be taking copious notes, help us reach more feds by signing up to write a short recap of the Public Private Partnerships Panel so we can share with the extended DigitalGov community.\\n\\nThe recap does not need to be more than a couple paragraphs and focus should be on the 3-5 key takeaways from each session. This is your opportunity to be an official reporter on the scene of this groundbreaking event. You’ll be taking notes live during the session and your report will be used as part of an overall event summary to be published on  [DigitalGov](http://www.digitalgov.gov/) for the world to see, and you will get a badge on the  [Open Opportunities](http://gsablogs.gsa.gov/dsic/category/open-opportunities/) our  [Wall of Fame](http://gsablogs.gsa.gov/dsic/category/wall-of-fame/). Panel summaries will be assigned on a first come first served basis.\n\n**Deadline:**  COB June 2\n\n**Duration:**  Up to 2 hours"
+  },
+  {
+    "createdAt": "2014-05-28T14:21:38+00:00",
+    "name": "recap-the-digitalgov-citizen-services-summit-inter-agency-work-panel",
+    "title": "Recap the DigitalGov Citizen Services Summit Inter-Agency Work Panel",
+    "state": "completed",
+    "description": "**Tapas**: Make your presence at the  [DigitalGov Summit](http://www.digitalgov.gov/event/digitalgov-citizen-services-summit/) count! Since you've already signed up and we know you'll be taking copious notes, help us reach more feds by signing up to write a short recap of the Inter-Agency Work Panel so we can share with the extended DigitalGov community.\\n\\nThe recap does not need to be more than a couple paragraphs and focus should be on the 3-5 key takeaways from each session. This is your opportunity to be an official reporter on the scene of this groundbreaking event. You’ll be taking notes live during the session and your report will be used as part of an overall event summary to be published on  [DigitalGov](http://www.digitalgov.gov/) for the world to see, and you will get a badge on the  [Open Opportunities](http://gsablogs.gsa.gov/dsic/category/open-opportunities/) our  [Wall of Fame](http://gsablogs.gsa.gov/dsic/category/wall-of-fame/). Panel summaries will be assigned on a first come first served basis.\n\n**Deadline:**  COB June 2\n\n**Duration:**  Up to 2 hours"
+  },
+  {
+    "createdAt": "2014-05-28T14:18:19+00:00",
+    "name": "socialize-the-digitalgov-citizen-services-summit",
+    "title": "Help socialize the Digitalgov Citizen Services Summit",
+    "state": "completed",
+    "description": "**Tapas**: We expect the [Digitalgov Citizen Services Summit](http://www.digitalgov.gov/event/digitalgov-citizen-services-summit/) to generate a lot of digital content and we want to be sure we capture the great stories as they are happening and share them. We are looking for a fed to take photos at  the event and share them on Google+, Twitter (using the [#digitalgov](https://twitter.com/search?q=%23digitalgov&src=typd) hashtag), Instagram, and Pinterest. The person should also retweet and share other people’s posts about the event.\\n\\n\n\nTask will be assigned on a first come first served basis. **Deadline** : June 3, 2014 **Duration:** Up to 2 hours (in addition to attending the Summit)"
+  },
+  {
+    "createdAt": "2014-05-28T13:59:23+00:00",
+    "name": "let-your-inner-data-detective-out-and-get-to-know-florida-or-your-favorite-state",
+    "title": "Let your inner data detective out and get to know Florida - moved to new platform",
+    "state": "completed",
+    "description": "**Tapas**: Summer is almost here and a trip to the _beach_ is right around the corner.  To get you in the mood for sun and fun why not get to know the state where your favorite beach is located?\n\n\\n\\n\n\n![](https://gsablogs.gsa.gov/dsic/wp-includes/js/tinymce/plugins/wordpress/img/trans.gif \"More...\")USA.gov searches across all federal, state, and local government websites–that’s hundreds of billions of pages from .gov and .mil websites plus  [over 11,000 .com, .org, etc. websites](http://govt-urls.usa.gov/tematres).\n\nHere’s your chance to improve the results searchers on USA.gov see for the state of Florida.\n\n1. Once you let us know that you’re interested, we’ll give you access to edit the known Florida websites directly:  [http://govt-urls.usa.gov/tematres/vocab/index.php?tema=43](http://govt-urls.usa.gov/tematres/vocab/index.php?tema=43)\n\n2. Your task is to visit the website for each FLA city, county, and state agency.\n\n3. Review the website to make sure it still belongs to an official government agency, and add a scope note to provide some basic bibliographic information about the agency.\n\n4. If you want to try this out but can’t tackle all the links, let us know! We still want to hear from you!\n\nIf there is a another state you prefer to work on let us know.  Chances are it is still available.\n\nPerfect for librarians, catalogers, or those who want to take a virtual tour.\n\n**Duration** : 20-24 hours **Deadline:** To be negotiated"
+  },
+  {
+    "createdAt": "2014-06-05T17:18:52+00:00",
+    "name": "help-dol-convert-this-huge-xml-file-to-json-parseltongue-may-be-required",
+    "title": "Help DOL convert this huge XML file to JSON (parseltongue may be required)",
+    "state": "completed",
+    "description": "**Tapas:** DOL would like to explore using an open source tool (Kibana) for visualizing open data easily and with minimal development. In order to make the case for development or a challenge to spur development in making the tool accessible to people with disabilities, we are looking to make the case with visualizations that would have a real-world impact: analyzing DOL’s API usage metrics.\n\n\\n\\n\n\nWe were able to extract the data to XML, however, ElasticSearch wants the data in JSON format.  The file is a little more than 1.4GB in size and the two python apps we’ve thrown at it, have failed to do anything. Are you willing to give it a try? **Duration:** Estimated effort: about 4 hours **Deadline:**  2 weeks after accepting the task"
+  },
+  {
+    "createdAt": "2014-06-05T19:22:55+00:00",
+    "name": "tell-stories-about-open-opps-innovators-and-the-results-they-have-achieved",
+    "title": "Interview an Open Opportunities innovator and share their experience",
+    "state": "completed",
+    "description": "**Tapas:** Are you an \"intrepid reporter\" who wants to learn more about open opportunities, the people participating in the program and the fantastic results achieved?\n\nThen this is for you. We want you to interview a few innovators and share their stories. Our goal is to increase the number of people participating in Open Opportunities and spread the word about the great work going on.\\n\\nWe’ll give you the contact info for the person you're to interview along with the areas we want to see covered:\n\nInterview should cover  four main elements:\n\n- What they did for open opps\n- Challenge\n- Solution\n- Results\nQuestions will need to be customized for each interview. Your mission (if you chose to accept it) will be to conduct a brief interview (phone or in-person - your choice), capture the answers to the questions, type them up, and send them to [lisa.nelson@gsa.gov](mailto:lisa.nelson@gsa.gov). In turn, the Open Opportunities team will review your story and and publish on [Digitalgov](http://www.digitalgov.gov/) and the [Open Opportunities for Digitalgov LinkedIn group](https://www.linkedin.com/groups?trk=anet_ug_hm&gid=5016512&home=&goback=%2Egna_5016512). **Duration:** 3-6 months **Deadline:** Ongoing"
+  },
+  {
+    "createdAt": "2014-06-10T16:01:31+00:00",
+    "name": "help-us-track-some-data-for-the-open-opportunities-program-2",
+    "title": "Track and analyze Open Opportunities performance metrics",
+    "state": "completed",
+    "description": "**20%**: The Open Opportunities Program was launched over a year ago and since the we have developed a solid group of performance metrics.  We are looking for someone to be responsible for analyzing and evaluating those metrics on a monthly basis. Specifically, we need someone to:\\n\\n\n- Analyze the data, identify issues and recommend changes\n- Ensures accuracy of data through partnerships with team members\n- Provides monthly summary of stats\n- Validates and spot checks\nDo you like numbers? Do you have a few hours every week for the next 6 months to help us keep track of this data? If you do, let us know! **Duration:**  6 months – Through Sept 30, 2014 **Deadline:  ** Ongoing"
+  },
+  {
+    "createdAt": "2014-06-13T17:26:45+00:00",
+    "name": "let-your-inner-data-detective-out-and-get-to-know-oregon",
+    "title": "Let your inner data detective out and get to know Oregon",
+    "state": "completed",
+    "description": "**Tapas**: USA.gov searches across all federal, state, and local government websites–that’s hundreds of billions of pages from .gov and .mil websites plus  [over 11,000 .com, .org, etc. websites](http://govt-urls.usa.gov/tematres).\n\nHere’s your chance to improve the results searchers on USA.gov see for the state of Oregon.\\n\\n\n\n1. Once you let us know that you’re interested, we’ll give you access to edit the known Oregon websites directly:  [http://govt-urls.usa.gov/tematres/vocab/index.php?tema=43](http://govt-urls.usa.gov/tematres/vocab/index.php?tema=43)\n\n2. Your task is to visit the website for each Oregon city, county, and state agency.\n\n3. Review the website to make sure it still belongs to an official government agency, and add a scope note to provide some basic bibliographic information about the agency.\n\n4. If you want to try this out but can’t tackle all the links, let us know! We still want to hear from you!\n\nIf there is a another state you prefer to work on let us know.  Chances are it is still available.\n\nPerfect for librarians, catalogers, or those who want to take a virtual tour.\n\n**Duration** : 20-24 hours **Deadline: ** To be negotiated"
+  },
+  {
+    "createdAt": "2014-06-11T16:00:07+00:00",
+    "name": "what-structured-content-can-do-for-you",
+    "title": "What Structured Content Can Do For You",
+    "state": "completed",
+    "description": "**Tapas**: Make your presence at our webinar count triple! If you’re joining us for the second webinar in our series “ [What Structured Content Can Do For You](https://www.digitalgov.gov/event/what-structured-content-can-do-for-you-article-model/)” help us reach more feds by writing a recap that we can share with the extended DigitalGov community.\n\n\\n\\n\n\nYou’ll be an active participant as the official reporter on the scene and allow us to give play by play details of this event. You’ll be taking notes live during the webinar but will have backstage access to the recording, the presenters and their notes afterwards to write your wrap up in plain language. Your report will be featured with your byline on  [DigitalGov](http://www.digitalgov.gov/) for the world to see and you will get a cool new press badge on our [ Wall of Fame.](http://gsablogs.gsa.gov/dsic/category/wall-of-fame/) **Deadline:**  June 19, 2014 **Duration** : 2-4 hours"
+  },
+  {
+    "createdAt": "2014-06-12T04:01:24+00:00",
+    "name": "create-a-storyboard-for-an-open-opportunities-video",
+    "title": "Create a storyboard for an Open Opportunities video",
+    "state": "completed",
+    "description": "**Tapas:** We need someone to help us create a blueprint for a video we are planning on how to write great Open Opportunities tasks. The blueprint should be in the form of a storyboard, using illustrations to map how the video will flow. We have collected best practice data on how to create the tasks and will provide them to you. What we want you do to do is concentrate on the visual representation.\\n\\nYou don't need to be an artist to do this just interested in helping us get the vision for the video down. Interested? Press the blue button! **Duration:** 2-4 hours **Deadline:** Two weeks after creating the task"
+  },
+  {
+    "createdAt": "2014-06-19T12:43:13+00:00",
+    "name": "be-a-mobile-tester",
+    "title": "Be A Mobile Tester!",
+    "state": "completed",
+    "description": "**Tapas:** Want to:\n\n- Learn more about responsively designed websites?\n- \n\nDirectly contribute to making a federal website better?\n\n- \n\nCollaborate with other Federal Employees?\\n\\n\n\nGrab your mobile device and join us as we crowd source test Defense Finance and Accounting Service (DFAS) website, June 23-30, 2014.\n\n No experience is necessary, just you and your mobile device (or devices.) If you are interested, include the device(s) you plan to test and their operating system(s) and versions (e.g. iPhone 5S, iOS 7.1.1)\n\n** Duration** : 2-4 hours (1 hour per mobile device, plus 1 hour to review preliminary material, and a 30 minute orientation call)\n\n**Deadline to sign up** : Friday, June 20, 2014"
+  },
+  {
+    "createdAt": "2014-06-24T20:47:46+00:00",
+    "name": "let-your-inner-data-detective-out-and-get-to-know-tennessee-3",
+    "title": "Let your inner data detective out and get to know Tennessee",
+    "state": "completed",
+    "description": "**Tapas**: USA.gov searches across all federal, state, and local government websites–that’s hundreds of billions of pages from .gov and .mil websites plus  [over 11,000 .com, .org, etc. websites](http://govt-urls.usa.gov/tematres).\n\nHere’s your chance to improve the results searchers on USA.gov see for the state of Tennessee.\\n\\n\n\n1. Once you let us know that you’re interested, we’ll give you access to edit the known Tennessee websites directly:  [http://govt-urls.usa.gov/tematres/vocab/index.php?tema=43](http://govt-urls.usa.gov/tematres/vocab/index.php?tema=43)\n\n2. Your task is to visit the website for each Tennessee city, county, and state agency.\n\n3. Review the website to make sure it still belongs to an official government agency, and add a scope note to provide some basic bibliographic information about the agency.\n\n4. If you want to try this out but can’t tackle all the links, let us know! We still want to hear from you!\n\nIf there is a another state you prefer to work on let us know.  Chances are it is still available.\n\nPerfect for librarians, catalogers, or those who want to take a virtual tour.\n\n**Duration** : 20-24 hours **Deadline: ** To be negotiated"
+  },
+  {
+    "createdAt": "2014-06-26T14:23:59+00:00",
+    "name": "convene-and-run-a-user-group-to-review-and-publish-accessibility-content-on-digitalgov",
+    "title": "Help us update accessibility content on DigitalGov",
+    "state": "completed",
+    "description": "**20%er**:  [Section 508](http://www.access-board.gov/guidelines-and-standards/communications-and-it/about-the-section-508-standards) mandates we provide all U.S. citizens with timely, usable access to government information, not just on websites, but across all digital platforms that customers use to interact with us. We need to update and improve the accessibility content from HowTo.gov for publishing on [DigitalGov](http://www.digitalgov.gov/), and we would like your help!\\n\\n\n\nWe are looking for someone to convene and run a user group of federal accessibility professionals interested in participating. Once convened, the user group will:\n\n- Review the existing content.\n- Identify holes in content and propose future articles for DigitalGov.\n- Coordinate updating of content for publishing on DigitalGov.\n- Propose ways to better align efforts with CIO Accessibility Committee.\n- Identify methods and resources for producing timely and new accessibility content and products in the future.\n\nThe format of the user group might include a monthly webinar/phone conference or what is best determined by the volunteers.\n\n**Duration:** 6 months **Deadline:** Ongoing"
+  },
+  {
+    "createdAt": "2014-06-27T13:46:40+00:00",
+    "name": "let-your-inner-data-detective-out-and-get-to-know-alaska",
+    "title": "Let your inner data detective out and get to know Alaska",
+    "state": "completed",
+    "description": "**Tapas**: USA.gov searches across all federal, state, and local government websites–that’s hundreds of billions of pages from .gov and .mil websites plus  [over 11,000 .com, .org, etc. websites](http://govt-urls.usa.gov/tematres).\n\nHere’s your chance to improve the results searchers on USA.gov see for the state of Alaska.\\n\\n\n\n1. Once you let us know that you’re interested, we’ll give you access to edit the known Alaska websites directly:  [http://govt-urls.usa.gov/tematres/vocab/index.php?tema=43](http://govt-urls.usa.gov/tematres/vocab/index.php?tema=43)\n\n2. Your task is to visit the website for each Alaska city, county, and state agency.\n\n3. Review the website to make sure it still belongs to an official government agency, and add a scope note to provide some basic bibliographic information about the agency.\n\n4. If you want to try this out but can’t tackle all the links, let us know! We still want to hear from you!\n\nIf there is a another state you prefer to work on let us know.  Chances are it is still available.\n\nPerfect for librarians, catalogers, or those who want to take a virtual tour.\n\n**Duration** : 20-24 hours **Deadline: ** To be negotiated"
+  },
+  {
+    "createdAt": "2014-06-27T20:52:50+00:00",
+    "name": "federal-crowdsource-mobile-testing-manager",
+    "title": "Federal CrowdSource Mobile Testing Manager",
+    "state": "completed",
+    "description": "**20%er** : Help create quality anytime, anywhere government by developing and managing a crowd-sourced Mobile Product Testing. The Mobile App Development program, part of the Digital Government Strategy, includes help for agencies in mobile product testing across a ton of different devices and operating systems.\\n\\nThis 20%er will manage a pilot program that will leverage the  [Open Opportunities program](https://www.digitalgov.gov/2014/06/23/hacking-the-bureaucracy-one-task-at-a-time/) to solicit people (federal employees) to use their own devices to help agencies test mobile products. The candidate will manage the match-making between testers and agencies and lead the evaluation of the program. Your experience with mobile products and project management is a plus. With the Assistance of the Digital Services Innovation Center team, your role will be: Program Management\n- Provide guidance for agencies conducting tests\n- Provide instructions, guidance for testers during test cycles\n- Tweak the program based on agency and tester experience\nRecruiting\n- Create user group for testers\n- Promote App to agencies\n- Look for opportunities for people to create agency-wide testing scripts\n**Deadline** : Ongoing **Duration** : 6 months"
+  },
+  {
+    "createdAt": "2014-06-27T21:19:16+00:00",
+    "name": "how-about-federal-crowdsource-mobile-testing-program-facilitator",
+    "title": "Federal CrowdSource Mobile Testing Program Facilitator",
+    "state": "completed",
+    "description": "**20%er** : The  [Federal Crowdsource Mobile Testing](http://www.digitalgov.gov/services/mobile-application-testing-program/) program is a service that helps agencies conduct compatibility testing on mobile websites. Testers from across the government volunteer to test these applications to ensure that they look and work well on various devices. The crowdsource mobile testing team wants your help with test cycles.\\n\\nThe proper candidate would help the testing coordinator manage test cycles by:\n\n- Attend test set up calls with new clients\n- Adjust templates from past cycles for emails that can be sent throughout new test-cycles\n- Collect Tester names and devices and record them in Google Doc when we test cycle advertising begins\n- Send test cycle correspondence and keep track of testers during the test-cycle and assist and send reminders/countdowns to keep it moving properly\n- Ensure test issues are documented in GitHub and receive additional materials from testers\n- Create Draft Testing Document\n- Develop methods and practices for improving flow of test cycle for testers and test facilitators.\n\n**Duration:** 4-6 months\n\n**Deadline:** Ongoing"
+  },
+  {
+    "createdAt": "2014-06-27T21:54:14+00:00",
+    "name": "let-your-inner-data-detective-out-and-get-to-know-kansas",
+    "title": "Let your inner data detective out and get to know Kansas",
+    "state": "completed",
+    "description": "**Tapas**: USA.gov searches across all federal, state, and local government websites–that’s hundreds of billions of pages from .gov and .mil websites plus  [over 11,000 .com, .org, etc. websites](http://govt-urls.usa.gov/tematres).\n\nHere’s your chance to improve the results searchers on USA.gov see for the state of Kansas.\\n\\n\n\n1. Once you let us know that you’re interested, we’ll give you access to edit the known Kansas websites directly:  [http://govt-urls.usa.gov/tematres/vocab/index.php?tema=43](http://govt-urls.usa.gov/tematres/vocab/index.php?tema=43)\n\n2. Your task is to visit the website for each Kansas city, county, and state agency.\n\n3. Review the website to make sure it still belongs to an official government agency, and add a scope note to provide some basic bibliographic information about the agency.\n\n4. If you want to try this out but can’t tackle all the links, let us know! We still want to hear from you!\n\nIf there is a another state you prefer to work on let us know.  Chances are it is still available.\n\nPerfect for librarians, catalogers, or those who want to take a virtual tour.\n\n**Duration** : 20-24 hours **Deadline: ** To be negotiated"
+  },
+  {
+    "createdAt": "2014-06-27T22:01:12+00:00",
+    "name": "let-your-inner-data-detective-out-and-get-to-know-new-jersey",
+    "title": "Let your inner data detective out and get to know New Jersey",
+    "state": "assigned",
+    "description": "**Tapas**: USA.gov searches across all federal, state, and local government websites–that’s hundreds of billions of pages from .gov and .mil websites plus  [over 11,000 .com, .org, etc. websites](http://govt-urls.usa.gov/tematres).\n\nHere’s your chance to improve the results searchers on USA.gov see for the state of New Jersey.\\n\\n\n\n1. Once you let us know that you’re interested, we’ll give you access to edit the known NJ websites directly:  [http://govt-urls.usa.gov/tematres/vocab/index.php?tema=43](http://govt-urls.usa.gov/tematres/vocab/index.php?tema=43)\n\n2. Your task is to visit the website for each NJ city, county, and state agency.\n\n3. Review the website to make sure it still belongs to an official government agency, and add a scope note to provide some basic bibliographic information about the agency.\n\n4. If you want to try this out but can’t tackle all the links, let us know! We still want to hear from you!\n\nIf there is a another state you prefer to work on let us know.  Chances are it is still available.\n\nPerfect for librarians, catalogers, or those who want to take a virtual tour.\n\n**Duration** : 16-24 hours **Deadline: ** To be negotiated"
+  },
+  {
+    "createdAt": "2014-06-30T14:46:53+00:00",
+    "name": "become-a-github-analytics-expert",
+    "title": "Become A GitHub Analytics Expert",
+    "state": "completed",
+    "description": "**20%er** : A lot of agencies are using Github and are looking at how the tool is performing for their programs. DigitalGov Innovators need leadership regarding using this analytics tool. Currently, the MobileGov Community of Practice has 3 Github repos where it needs analytics expertise.\\n\\nThe right candidate would:\n\n- Research Github analytics to understand how to measure performance\n- Monitor the 3 Mobile Gov Github Repos and provide analytics data to mobile manager\n- Analyze corrleations between promotion, events and traffic, pull requests, comments, etc. in the 3 repos\n- Work with the Mobile manager to identify gaps in GH analytics for government and to make recommendations with the GH government group\n- Develop good practices and document them on DigitalGov via post, webinar, etc.\n\n**Duration** : 4-6 months\n\n**Deadline:** Ongoing"
+  },
+  {
+    "createdAt": "2014-06-27T22:08:41+00:00",
+    "name": "let-your-inner-data-detective-out-and-get-to-know-pennsylvania",
+    "title": "Let your inner data detective out and get to know Pennsylvania",
+    "state": "completed",
+    "description": "**Tapas**: USA.gov searches across all federal, state, and local government websites–that’s hundreds of billions of pages from .gov and .mil websites plus  [over 11,000 .com, .org, etc. websites](http://govt-urls.usa.gov/tematres).\n\nHere’s your chance to improve the results searchers on USA.gov see for the state of Pennsylvania.\\n\\n\n\n1. Once you let us know that you’re interested, we’ll give you access to edit the known PA websites directly:  [http://govt-urls.usa.gov/tematres/vocab/index.php?tema=43](http://govt-urls.usa.gov/tematres/vocab/index.php?tema=43)\n\n2. Your task is to visit the website for each PA city, county, and state agency.\n\n3. Review the website to make sure it still belongs to an official government agency, and add a scope note to provide some basic bibliographic information about the agency.\n\n4. If you want to try this out but can’t tackle all the links, let us know! We still want to hear from you!\n\nIf there is a another state you prefer to work on let us know.  Chances are it is still available.\n\nPerfect for librarians, catalogers, or those who want to take a virtual tour.\n\n**Duration** : 20-24 hours **Deadline: ** To be negotiated"
+  },
+  {
+    "createdAt": "2014-07-01T20:54:07+00:00",
+    "name": "let-your-inner-data-detective-out-and-get-to-know-illinois",
+    "title": "Let your inner data detective out and get to know Illinois",
+    "state": "completed",
+    "description": "**Tapas**: USA.gov searches across all federal, state, and local government websites–that’s hundreds of billions of pages from .gov and .mil websites plus  [over 11,000 .com, .org, etc. websites](http://govt-urls.usa.gov/tematres).\n\nHere’s your chance to improve the results searchers on USA.gov see for the state of Illinois.\\n\\n\n\n1. Once you let us know that you’re interested, we’ll give you access to edit the known Illinois websites directly:  [http://govt-urls.usa.gov/tematres/vocab/index.php?tema=43](http://govt-urls.usa.gov/tematres/vocab/index.php?tema=43)\n\n2. Your task is to visit the website for each Illinois city, county, and state agency.\n\n3. Review the website to make sure it still belongs to an official government agency, and add a scope note to provide some basic bibliographic information about the agency.\n\n4. If you want to try this out but can’t tackle all the links, let us know! We still want to hear from you!\n\nIf there is a another state you prefer to work on let us know.  Chances are it is still available.\n\nPerfect for librarians, catalogers, or those who want to take a virtual tour.\n\n**Duration** : 20-24 hours **Deadline: ** To be negotiated"
+  },
+  {
+    "createdAt": "2014-07-02T21:00:06+00:00",
+    "name": "be-a-mobile-tester-2",
+    "title": "Be a mobile tester!",
+    "state": "completed",
+    "description": "**Tapas**: Want to:\n- Learn more about responsively designed websites?\n- Directly contribute to making a federal website better?\n- Collaborate with other Federal Employees?\\n\\n\nGrab your mobile device and join us as we crowd source test Administration for Children and Families (ACF) responsive website, July 16-23, 2014. No experience is necessary, just you and your mobile device (or devices.) If you are interested, include the device(s) you plan to test and their operating system(s) and versions (e.g. iPhone 5S, iOS 7.1.1) **Duration** : 2-4 hours (1 hour per mobile device, plus 1 hour to review preliminary material, and a 30 minute orientation call) **Deadline to sign up:** Tuesday, July 16 by noon."
+  },
+  {
+    "createdAt": "2014-07-08T14:08:14+00:00",
+    "name": "let-your-inner-data-detective-out-and-get-to-know-mississippi",
+    "title": "Let your inner data detective out and get to know Mississippi",
+    "state": "completed",
+    "description": "**Tapas**: USA.gov searches across all federal, state, and local government websites–that’s hundreds of billions of pages from .gov and .mil websites plus  [over 11,000 .com, .org, etc. websites](http://govt-urls.usa.gov/tematres).\n\nHere’s your chance to improve the results searchers on USA.gov see for the state of Mississippi.\n\n\\n\\n\n\n1. Once you let us know that you’re interested, we’ll give you access to edit the known Mississippi websites directly:  [http://govt-urls.usa.gov/tematres/vocab/index.php?tema=43](http://govt-urls.usa.gov/tematres/vocab/index.php?tema=43)\n\n2. Your task is to visit the website for each Misissippi city, county, and state agency.\n\n3. Review the website to make sure it still belongs to an official government agency, and add a scope note to provide some basic bibliographic information about the agency.\n\n4. If you want to try this out but can’t tackle all the links, let us know! We still want to hear from you!\n\nIf there is a another state you prefer to work on let us know.  Chances are it is still available.\n\nPerfect for librarians, catalogers, or those who want to take a virtual tour.\n\n**Duration** : 20-24 hours **Deadline: ** To be negotiated"
+  },
+  {
+    "createdAt": "2014-07-10T02:26:10+00:00",
+    "name": "help-us-improve-the-usa-gov-apps-gallery",
+    "title": "Help us improve the USA.gov Apps Gallery!",
+    "state": "completed",
+    "description": "**Tapas**: We need a few good folks to help us update the Federal Mobile Apps Registry API by updating the icon URL of 20 mobile apps located in the USA.gov Apps Gallery. Here’s how it will work:\\n\\n\n\nWe’ll provide you with a list of 20 government apps and their iOS’ App store and/or Google play icon URLs. You will update the government app's registry listing with the icon's URL. You will have completed the task when you have added your listing of icon URLs to the registry. The data you provide will help us improve the next iteration of the USA.gov Apps Gallery. **Duration** : 1-2 hours **Deadline** : Task should be completed within two weeks of us providing you with the spreadsheet."
+  },
+  {
+    "createdAt": "2014-07-10T16:50:11+00:00",
+    "name": "let-your-inner-data-detective-out-and-get-to-know-colorado",
+    "title": "Let your inner \"data detective\" out and get to know Colorado",
+    "state": "completed",
+    "description": "**Tapas**: USA.gov searches across all federal, state, and local government websites–that’s hundreds of billions of pages from .gov and .mil websites plus  [over 11,000 .com, .org, etc. websites](http://govt-urls.usa.gov/tematres).\n\nHere’s your chance to improve the results searchers on USA.gov see for the state of Colorado. ![](https://gsablogs.gsa.gov/dsic/wp-includes/js/tinymce/plugins/wordpress/img/trans.gif \"More...\")\n\n\\n\\n\n\n1. Once you let us know that you’re interested, we’ll give you access to edit the known Colorado websites directly:  [http://govt-urls.usa.gov/tematres/vocab/index.php?tema=43](http://govt-urls.usa.gov/tematres/vocab/index.php?tema=43)\n\n2. Your task is to visit the website for each Colorado city, county, and state agency.\n\n3. Review the website to make sure it still belongs to an official government agency, and add a scope note to provide some basic bibliographic information about the agency.\n\n4. If you want to try this out but can’t tackle all the links, let us know! We still want to hear from you!\n\nIf there is a another state you prefer to work on let us know.  Chances are it is still available.\n\nPerfect for librarians, catalogers, or those who want to take a virtual tour.\n\n**Duration** : 20-24 hours **Deadline: ** To be negotiated"
+  },
+  {
+    "createdAt": "2014-07-11T16:56:40+00:00",
+    "name": "star-in-a-how-to-do-an-ignite-ignite",
+    "title": "Help create an ignite presentation on \"How to do an ignite\"",
+    "state": "completed",
+    "description": "**Tapas:** Have you ever created an ignite session presentation? This challenging, 5 minute, 20 slide, auto-advancing style presentation is elusive to even experienced presenters.\n\nWe at [DigitalGov U](http://www.digitalgov.gov/digitalgov-university/) (DGU) think that this is a compelling way to present ideas and spark discussions. It’s been hard to get our community members to volunteer to present in this way, though.\\n\\n\n\nSo, DGU wants to enlighten them. We’d like someone to help us develop the steps it takes to create a stellar ignite.  We will use these steps to create a storyboard . Then, finally we will record an ignite presentation on “how to do an ignite presentation”.\n\n**Duration** :  8-16 hours\n\n**Deadline:** To be determined"
+  },
+  {
+    "createdAt": "2014-07-14T13:58:08+00:00",
+    "name": "let-your-inner-data-detective-out-and-get-to-know-idaho",
+    "title": "Let your inner data detective out and get to know Idaho",
+    "state": "completed",
+    "description": "**Tapas**: USA.gov searches across all federal, state, and local government websites–that’s hundreds of billions of pages from .gov and .mil websites plus  [over 11,000 .com, .org, etc. websites](http://govt-urls.usa.gov/tematres).\n\nHere’s your chance to improve the results searchers on USA.gov see for the state of Idaho.\\n\\n\n\n1. Once you let us know that you’re interested, we’ll give you access to edit the known Idaho websites directly:  [http://govt-urls.usa.gov/tematres/vocab/index.php?tema=43](http://govt-urls.usa.gov/tematres/vocab/index.php?tema=43)\n\n2. Your task is to visit the website for each Idaho city, county, and state agency.\n\n3. Review the website to make sure it still belongs to an official government agency, and add a scope note to provide some basic bibliographic information about the agency.\n\n4. If you want to try this out but can’t tackle all the links, let us know! We still want to hear from you!\n\nIf there is a another state you prefer to work on let us know.  Chances are it is still available.\n\nPerfect for librarians, catalogers, or those who want to take a virtual tour.\n\n**Duration** : 20-24 hours **Deadline: ** To be negotiated"
+  },
+  {
+    "createdAt": "2014-07-14T16:53:53+00:00",
+    "name": "transform-a-flat-text-file-into-an-api",
+    "title": "Transform a flat text file into an API",
+    "state": "completed",
+    "description": "**Tapas: **USA.gov searches across all federal, state, and local government websites–that’s hundreds of billions of pages from .gov and .mil websites plus over 11,000 .com, .org, etc. websites.\n\nWe maintain this list at [http://govt-urls.usa.gov/tematres/vocab/index.php](http://govt-urls.usa.gov/tematres/vocab/index.php) and make periodic updates as we come across changes.\\n\\n\n\nEach quarter, we also [post the URLs in Github](https://github.com/GSA/govt-urls/) in three files.\n\n1. Alphabetic—an A-Z list of URLs with accompanying notes and relationships collected over time.\n\n2. Hierarchical—a flat list of URLs segmented by category.\n\n3. YAML—a mapping file of the URLs for applications.\n\nHere’s your chance to unleash the power of this list by helping developers access it via an API.\n\nYour task is to [offer an API for the URLs](https://github.com/GSA/govt-urls/issues/1). **Duration** : 4 to 8 hours **Deadline** :  To be negotiated"
+  },
+  {
+    "createdAt": "2014-07-15T14:28:30+00:00",
+    "name": "let-your-inner-data-detective-out-and-get-to-know-new-mexico",
+    "title": "Let your inner \"data detective\" out and get to know New Mexico",
+    "state": "completed",
+    "description": "**Tapas**: USA.gov searches across all federal, state, and local government websites–that’s hundreds of billions of pages from .gov and .mil websites plus  [over 11,000 .com, .org, etc. websites](http://govt-urls.usa.gov/tematres).\n\nHere’s your chance to improve the results searchers on USA.gov see for the state of New Mexico.\\n\\n\n\n1. Once you let us know that you’re interested, we’ll give you access to edit the known New Mexico websites directly:  [http://govt-urls.usa.gov/tematres/vocab/index.php?tema=43](http://govt-urls.usa.gov/tematres/vocab/index.php?tema=43)\n\n2. Your task is to visit the website for each New Mexico city, county, and state agency.\n\n3. Review the website to make sure it still belongs to an official government agency, and add a scope note to provide some basic bibliographic information about the agency.\n\n4. If you want to try this out but can’t tackle all the links, let us know! We still want to hear from you!\n\nIf there is a another state you prefer to work on let us know.  Chances are it is still available.\n\nPerfect for librarians, catalogers, or those who want to take a virtual tour.\n\n**Duration** : 20-24 hours **Deadline: ** To be negotiated"
+  },
+  {
+    "createdAt": "2014-07-16T17:23:09+00:00",
+    "name": "let-your-inner-data-detective-out-and-get-to-know-south-dakota",
+    "title": "Let your inner \"data detective\" out and get to know South Dakota",
+    "state": "completed",
+    "description": "**Tapas**: USA.gov searches across all federal, state, and local government websites–that’s hundreds of billions of pages from .gov and .mil websites plus  [over 11,000 .com, .org, etc. websites](http://govt-urls.usa.gov/tematres).\n\nHere’s your chance to improve the results searchers on USA.gov see for the state of South Dakota.\\n\\n\n\n1. Once you let us know that you’re interested, we’ll give you access to edit the known South Dakota websites directly:  [http://govt-urls.usa.gov/tematres/vocab/index.php?tema=43](http://govt-urls.usa.gov/tematres/vocab/index.php?tema=43)\n\n2. Your task is to visit the website for each South Dakota city, county, and state agency.\n\n3. Review the website to make sure it still belongs to an official government agency, and add a scope note to provide some basic bibliographic information about the agency.\n\n4. If you want to try this out but can’t tackle all the links, let us know! We still want to hear from you!\n\nIf there is a another state you prefer to work on let us know.  Chances are it is still available.\n\nPerfect for librarians, catalogers, or those who want to take a virtual tour.\n\n**Duration** : 20-24 hours **Deadline: ** To be negotiated"
+  },
+  {
+    "createdAt": "2014-07-16T18:02:22+00:00",
+    "name": "mobile-trends-on-tuesday-tracker",
+    "title": "Mobile Trends on Tuesday Tracker",
+    "state": "completed",
+    "description": "**Tapas:** Help us track down mobile trends for [DigitalGov Mobile Trends on Tuesday posts](https://www.digitalgov.gov/tag/trends-on-tuesday/)! We are always on the trail of trends to highlight the case for mobile, and you can help us by finding two current mobile trends that cover changing user habits, social media and other ways mobile technology is changing the digital landscape.  We’ll provide a list of likely sources, then turn you loose to trap two recent trends (within the last two months).\\n\\n\n\n**Duration:** 1-2 hours\n\n**Deadline:** Task should be completed within a week after acceptance."
+  },
+  {
+    "createdAt": "2014-07-16T18:05:13+00:00",
+    "name": "transform-a-word-doc-into-an-html-page-on-github",
+    "title": "Transform a Word Doc into an HTML page on GitHub",
+    "state": "completed",
+    "description": "**Tapas:** Help us improve our [Crowdsource Testing Program](https://www.digitalgov.gov/services/mobile-application-testing-program/)! We’re looking for someone with some coding know how to help us make GitHub easier for our testers to understand. We have a Word document with instructions for our crowdsource testers on how to use GitHub, and would like to have someone turn it into an HTML page on GitHub.\\n\\n\n\nOnce you accept this task, we’ll send you the seven page document (with 10 included images) for you to transform.\n\n**Duration** : 2-4 hours\n\n**Deadline** : Task should be completed within two weeks after acceptance"
+  },
+  {
+    "createdAt": "2014-07-17T21:03:09+00:00",
+    "name": "let-your-inner-data-detective-out-and-get-to-know-north-dakota",
+    "title": "Let your inner \"data detective\" out and get to know North Dakota",
+    "state": "completed",
+    "description": "**Tapas**: USA.gov searches across all federal, state, and local government websites–that’s hundreds of billions of pages from .gov and .mil websites plus  [over 11,000 .com, .org, etc. websites](http://govt-urls.usa.gov/tematres).\n\nHere’s your chance to improve the results searchers on USA.gov see for the state of North Dakota.\n\n\\n\\n\n\n1. Once you let us know that you’re interested, we’ll give you access to edit the known North Dakota websites directly:  [http://govt-urls.usa.gov/tematres/vocab/index.php?tema=43](http://govt-urls.usa.gov/tematres/vocab/index.php?tema=43)\n\n2. Your task is to visit the website for each North Dakota city, county, and state agency.\n\n3. Review the website to make sure it still belongs to an official government agency, and add a scope note to provide some basic bibliographic information about the agency.\n\n4. If you want to try this out but can’t tackle all the links, let us know! We still want to hear from you!\n\nIf there is a another state you prefer to work on let us know.  Chances are it is still available.\n\nPerfect for librarians, catalogers, or those who want to take a virtual tour.\n\n**Duration** : 20-24 hours **Deadline: ** To be negotiated"
+  },
+  {
+    "createdAt": "2014-07-22T20:23:18+00:00",
+    "name": "6882",
+    "title": "Let your inner \"data detective\" out and get to know Wyoming",
+    "state": "completed",
+    "description": "**Tapas**: USA.gov searches across all federal, state, and local government websites–that’s hundreds of billions of pages from .gov and .mil websites plus  [over 11,000 .com, .org, etc. websites](http://govt-urls.usa.gov/tematres).\n\nHere’s your chance to improve the results searchers on USA.gov see for the state of Wyoming.\\n\\n\n\n1. Once you let us know that you’re interested, we’ll give you access to edit the known Wyoming websites directly:  [http://govt-urls.usa.gov/tematres/vocab/index.php?tema=43](http://govt-urls.usa.gov/tematres/vocab/index.php?tema=43)\n\n2. Your task is to visit the website for each Wyoming city, county, and state agency.\n\n3. Review the website to make sure it still belongs to an official government agency, and add a scope note to provide some basic bibliographic information about the agency.\n\n4. If you want to try this out but can’t tackle all the links, let us know! We still want to hear from you!\n\nIf there is a another state you prefer to work on let us know.  Chances are it is still available.\n\nPerfect for librarians, catalogers, or those who want to take a virtual tour.\n\n**Duration** : 20-24 hours **Deadline: ** To be negotiated"
+  },
+  {
+    "createdAt": "2014-07-23T21:40:18+00:00",
+    "name": "help-make-government-mobile-by-recapping-a-responsive-web-design-webinar",
+    "title": "Help Make Government Mobile By Recapping A Responsive Web Design Webinar",
+    "state": "completed",
+    "description": "**Tapas:** Make your presence at the July 30th [How to Use Open Source Content Management Systems to Implement Responsive Web Design](http://www.digitalgov.gov/event/mobile-web-templates-how-to-use-open-source-cms-to-implement-responsive-web-design/) webinar count triple! Sign up if you haven' already, take copious notes, and tell the larger DigitalGov Community how open source CMS can help feds mobilize their information.\n\n\\n\\nThe [DigitalGov.gov](http://www.digitalgov.gov/) recap does not need to be more than a couple paragraphs and the focus should be on the 3-5 key takeaways from each speaker. You will have access to the transcript and speakers after the webinar to help make your recap the greatest! **Deadline:**  August 6th, 2014 **Duration** : up to 3 hours"
+  },
+  {
+    "createdAt": "2014-07-23T21:59:23+00:00",
+    "name": "design-a-cool-mobile-code-chop-shop-graphic",
+    "title": "Design A Cool Mobile Code Chop Shop Graphic",
+    "state": "completed",
+    "description": "**Tapas**: Imagine having your designs highlighted to all of government for an innovative project. With every post and event we publish on DigitalGov.gov, we're looking for engaging art. We need someone with a knack for graphics to come up with an engaging and interesting graphic for our MobileGov Code Chop Shops. Whenever we post or talk about the chop shop on DigitalGov, we will use your art. We have some cool ideas but want your input! **Deadline:**  August 22nd, 2014 **Duration** : up to 6 hours"
+  },
+  {
+    "createdAt": "2014-07-24T12:53:21+00:00",
+    "name": "6932",
+    "title": "Let your inner \"data detective\" out and get to know West Virginia",
+    "state": "completed",
+    "description": "**Tapas**: USA.gov searches across all federal, state, and local government websites–that’s hundreds of billions of pages from .gov and .mil websites plus  [over 11,000 .com, .org, etc. websites](http://govt-urls.usa.gov/tematres).\n\nHere’s your chance to improve the results searchers on USA.gov see for the state of West Virginia.\\n\\n\n\n1. Once you let us know that you’re interested, we’ll give you access to edit the known West Virginia websites directly:  [http://govt-urls.usa.gov/tematres/vocab/index.php?tema=43](http://govt-urls.usa.gov/tematres/vocab/index.php?tema=43)\n\n2. Your task is to visit the website for each West Virginia city, county, and state agency.\n\n3. Review the website to make sure it still belongs to an official government agency, and add a scope note to provide some basic bibliographic information about the agency.\n\n4. If you want to try this out but can’t tackle all the links, let us know! We still want to hear from you!\n\nIf there is a another state you prefer to work on let us know.  Chances are it is still available.\n\nPerfect for librarians, catalogers, or those who want to take a virtual tour.\n\n**Duration** : 20-24 hours **Deadline: ** To be negotiated"
+  },
+  {
+    "createdAt": "2014-07-24T13:09:52+00:00",
+    "name": "let-your-inner-data-detective-out-and-get-to-know-wisconsin",
+    "title": "Let your inner \"data detective\" out and get to know Wisconsin",
+    "state": "completed",
+    "description": "**Tapas**: USA.gov searches across all federal, state, and local government websites–that’s hundreds of billions of pages from .gov and .mil websites plus  [over 11,000 .com, .org, etc. websites](http://govt-urls.usa.gov/tematres).\n\nHere’s your chance to improve the results searchers on USA.gov see for the state of Wisconsin.\n\n\\n\\n\n\n1. Once you let us know that you’re interested, we’ll give you access to edit the known Wisconsin websites directly:  [http://govt-urls.usa.gov/tematres/vocab/index.php?tema=43](http://govt-urls.usa.gov/tematres/vocab/index.php?tema=43)\n\n2. Your task is to visit the website for each Wisconsin city, county, and state agency.\n\n3. Review the website to make sure it still belongs to an official government agency, and add a scope note to provide some basic bibliographic information about the agency.\n\n4. If you want to try this out but can’t tackle all the links, let us know! We still want to hear from you!\n\nIf there is a another state you prefer to work on let us know.  Chances are it is still available.\n\nPerfect for librarians, catalogers, or those who want to take a virtual tour.\n\n**Duration** : 20-24 hours **Deadline: ** To be negotiated"
+  },
+  {
+    "createdAt": "2014-07-31T20:10:58+00:00",
+    "name": "be-a-usability-tester",
+    "title": "Be a usability tester!",
+    "state": "completed",
+    "description": "**Tapas:** Federal systems are focusing more and more on the User Experience, but they need people to test their websites in order to get this valuable feedback. We're looking for federal employees who are willing to give a little bit of their time - either in person or virtually - to test these websites. Help improve federal digital government! **Duration:** 30 minutes - 1 hour"
+  },
+  {
+    "createdAt": "2014-08-07T14:42:46+00:00",
+    "name": "seeking-android-users-to-test-a-noaa-native-app-or-be-a-mobile-tester",
+    "title": "Seeking Android users to test a NOAA native app! (OR be a mobile tester)",
+    "state": "completed",
+    "description": "**Tapas**: Grab your mobile device and join us as we crowdsource test the NOAA CrowdMag App on August 18-29th, 2014. The NOAA CrowdMag project explores whether digital magnetometers built in modern mobile phones can be used as scientific instruments. The CrowdMag App uses a phone's internet connection to send magnetic and location data to NOAA’s National Geophysical Data Center (NGDC). NGDC analyzes the magnetic data for research purpose and make the results available to users via native app and web-sites. For this test you will download the app and not only review it for compatibility but also keep the app on your device for a week to help NOAA test the data collection functionality and check it periodically to see how it affects your device. No experience is necessary, just you and your Android smartphone. If you are interested, let us know now. **Duration:** 2-4 hours **Deadline** : Testing should be complete by August 29"
+  },
+  {
+    "createdAt": "2014-08-07T16:30:43+00:00",
+    "name": "training-specialist-for-digital-analytics-program-dap",
+    "title": "Help us take digital analytics training to agencies across the government",
+    "state": "completed",
+    "description": "**20%:** The [Digital Analytics Program](http://www.digitalgov.gov/services/dap/)(DAP) is seeking someone passionate about analytics to train the growing number of users working with the Web-analytics program. Work will involve preparing for (materials, presentations, documentation etc.) and assisting/running DAP Google Analytics (GA) quarterly in-person training sessions and webinars for the government-wide DAP user group.\n\n\\n\\nDAP currently has 32 participating agencies, more than 3000 websites, and nearly 1200 individual users using DAP GA. The training specialist also would be involved on on-going collaboration and user group communication via the DAP Online User Group on Yammer to support knowledge sharing, reporting tips and strategies, analysis topics etc.\n\n**Deadline** : Until assigned\n\n**Duration** : 6 months from accepting task"
+  },
+  {
+    "createdAt": "2014-08-12T21:22:41+00:00",
+    "name": "federal-crowdsource-mobile-testing-manager-2",
+    "title": "Federal CrowdSource Mobile Testing Manager",
+    "state": "completed",
+    "description": "Help create quality anytime, anywhere government by developing and managing a crowd-sourced Mobile Product Testing. The Mobile App Development program, part of the Digital Government Strategy, includes help for agencies in mobile product testing across a ton of different devices and operating systems. This 20%er will manage a pilot program that will leverage the  [Open Opportunities program](https://www.digitalgov.gov/2014/06/23/hacking-the-bureaucracy-one-task-at-a-time/) to solicit people (federal employees) to use their own devices to help agencies test mobile products. The candidate will manage the match-making between testers and agencies and lead the evaluation of the program. Your experience with mobile products and project management is a plus. With the Assistance of the Digital Services Innovation Center team, your role will be: Program Management\n- Provide guidance for agencies conducting tests\n- Provide instructions, guidance for testers during test cycles\n- Tweak the program based on agency and tester experience\nRecruiting\n- Create user group for testers\n- Promote App to agencies\n- Look for opportunities for people to create agency-wide testing scripts"
+  },
+  {
+    "createdAt": "2014-08-13T15:37:28+00:00",
+    "name": "help-create-quality-anytime-anywhere-government-by-developing-and-managing-a-crowd-sourced-mobile-product-testing-program",
+    "title": "Help create quality anytime, anywhere government by developing and managing a crowd-sourced Mobile Product Testing program",
+    "state": "completed",
+    "description": "**20%er**: Help create quality anytime, anywhere government by developing and managing a crowd-sourced Mobile Product Testing program.\\n\\nThe Mobile App Development program, part of the Digital Government Strategy, includes help for agencies in mobile product testing across a ton of different devices and operating systems. This 20%er will manage a testing program that will leverage the  [Open Opportunities program](https://www.digitalgov.gov/2014/06/23/hacking-the-bureaucracy-one-task-at-a-time/) to solicit people (federal employees) to use their own devices to help agencies test mobile products. The candidate will manage the match-making between testers and agencies and lead the evaluation of the program. Your experience with mobile products and project management is a plus. With the Assistance of the Digital Services Innovation Center team, your role will be: Program Management\n- Provide guidance for agencies conducting tests\n- Recruit federal employees to help conduct test cycles\n- Provide instructions, guidance for testers during test cycles\n- Tweak the program based on agency and tester experience (ie try native app testing)\n\n- Create user group for testers\n- Explore opportunities for developing government-wide mobile testing scripts\n**Deadline** : Ongoing **Duration** : 6 months"
+  },
+  {
+    "createdAt": "2014-08-15T16:18:51+00:00",
+    "name": "let-your-inner-data-detective-out-and-get-to-know-vermont",
+    "title": "Let your inner “data detective” out and get to know Vermont",
+    "state": "completed",
+    "description": "**Tapas**: USA.gov searches across all federal, state, and local government websites–that’s hundreds of billions of pages from .gov and .mil websites plus  [over 11,000 .com, .org, etc. websites](http://govt-urls.usa.gov/tematres). Here’s your chance to improve the results searchers on USA.gov see for the state of Vermont.\n\n1. Once you let us know that you’re interested, we’ll give you access to edit the known Vermont websites directly:  [http://govt-urls.usa.gov/tematres/vocab/index.php?tema=43](http://govt-urls.usa.gov/tematres/vocab/index.php?tema=43)\n\n2. Your task is to visit the website for each Vermont city, county, and state agency.\n\n3. Review the website to make sure it still belongs to an official government agency, and add a scope note to provide some basic bibliographic information about the agency.\n\n4. If you want to try this out but can’t tackle all the links, let us know! We still want to hear from you!\n\nIf there is a another state you prefer to work on let us know.  Chances are it is still available.\n\nPerfect for librarians, catalogers, or those who want to take a virtual tour.\n\n**Duration** : 20-24 hours **Deadline: ** To be negotiated"
+  },
+  {
+    "createdAt": "2014-08-18T16:26:24+00:00",
+    "name": "7352",
+    "title": "Let your inner \"data detective\" out and get to know the Virgin Islands",
+    "state": "completed",
+    "description": "**Tapas**: USA.gov searches across all federal, state, and local government websites–that’s hundreds of billions of pages from .gov and .mil websites plus  [over 11,000 .com, .org, etc. websites](http://govt-urls.usa.gov/tematres). Here’s your chance to improve the results searchers on USA.gov see for the U.S. Virgin Islands.\n\n1. Once you let us know that you’re interested, we’ll give you access to edit the known U.S. Virgin Islands websites directly:  [http://govt-urls.usa.gov/tematres/vocab/index.php?tema=43](http://govt-urls.usa.gov/tematres/vocab/index.php?tema=43)\n\n2. Your task is to visit the website for each U.S. Virgin Islands agency.\n\n3. Review the website to make sure it still belongs to an official government agency, and add a scope note to provide some basic bibliographic information about the agency.\n\n4. If you want to try this out but can’t tackle all the links, let us know! We still want to hear from you!\n\nIf there is a another state you prefer to work on let us know.  Chances are it is still available.\n\nPerfect for librarians, catalogers, or those who want to take a virtual tour.\n\n**Duration** : 20-24 hours **Deadline: ** To be negotiated"
+  },
+  {
+    "createdAt": "2014-08-18T16:43:35+00:00",
+    "name": "let-your-inner-data-detective-out-and-get-to-know-utah",
+    "title": "Let your inner \"data detective\" out and get to know Utah",
+    "state": "completed",
+    "description": "**Tapas**: USA.gov searches across all federal, state, and local government websites–that’s hundreds of billions of pages from .gov and .mil websites plus  [over 11,000 .com, .org, etc. websites](http://govt-urls.usa.gov/tematres). Here’s your chance to improve the results searchers on USA.gov see for the state of Utah.\n\n1. Once you let us know that you’re interested, we’ll give you access to edit the known Utah websites directly:  [http://govt-urls.usa.gov/tematres/vocab/index.php?tema=43](http://govt-urls.usa.gov/tematres/vocab/index.php?tema=43)\n\n2. Your task is to visit the website for each Utah city, county, and state agency.\n\n3. Review the website to make sure it still belongs to an official government agency, and add a scope note to provide some basic bibliographic information about the agency.\n\n4. If you want to try this out but can’t tackle all the links, let us know! We still want to hear from you!\n\nIf there is a another state you prefer to work on let us know.  Chances are it is still available.\n\nPerfect for librarians, catalogers, or those who want to take a virtual tour.\n\n**Duration** : 20-24 hours **Deadline: ** To be negotiated"
+  },
+  {
+    "createdAt": "2014-08-21T15:23:05+00:00",
+    "name": "interview-an-open-opportunities-innovator-and-share-their-experience",
+    "title": "Interview an Open Opportunities innovator and share their experience (2)",
+    "state": "completed",
+    "description": "**Tapas:** Are you an “intrepid reporter” who wants to learn more about open opportunities, the people participating in the program and the fantastic results achieved?\\n\\n\n\nThen this is for you. We want you to interview an innovator and share their story. Our goal is to increase the number of people participating in Open Opportunities and spread the word about the great work going on. We’ll give you the contact info for the person you’re to interview along with the areas we want to see covered:\n\nInterview should cover  four main elements:\n\n- What they did for open opps\n- Challenge\n- Solution\n- Results\nQuestions will need to be customized for each interview. Your mission (if you chose to accept it) will be to conduct a brief interview (phone or in-person – your choice), capture the answers to the questions, type them up, and send them to  [lisa.nelson@gsa.gov](mailto:lisa.nelson@gsa.gov). In turn, the Open Opportunities team will review your story and and publish on  [Digitalgov](http://www.digitalgov.gov/) and the [Open Opportunities for Digitalgov LinkedIn group](https://www.linkedin.com/groups?trk=anet_ug_hm&gid=5016512&home=&goback=%2Egna_5016512). **Duration:** 2-4 hours **Deadline:**  2 weeks after accepting the task"
+  },
+  {
+    "createdAt": "2014-08-25T13:38:08+00:00",
+    "name": "let-your-inner-data-detective-out-and-get-to-know-washington-state",
+    "title": "Let your inner \"data detective\" out and get to know Washington State",
+    "state": "completed",
+    "description": "**Tapas**: USA.gov searches across all federal, state, and local government websites–that’s hundreds of billions of pages from .gov and .mil websites plus  [over 11,000 .com, .org, etc. websites](http://govt-urls.usa.gov/tematres).\\n\\nHere’s your chance to improve the results searchers on USA.gov see for the Washington State.\n\n1. Once you let us know that you’re interested, we’ll give you access to edit the known Washington State websites directly:  [http://govt-urls.usa.gov/tematres/vocab/index.php?tema=43](http://govt-urls.usa.gov/tematres/vocab/index.php?tema=43)\n\n2. Your task is to visit the website for each Washington state city, county, and state agency.\n\n3. Review the website to make sure it still belongs to an official government agency, and add a scope note to provide some basic bibliographic information about the agency.\n\n4. If you want to try this out but can’t tackle all the links, let us know! We still want to hear from you!\n\nIf there is a another state you prefer to work on let us know.  Chances are it is still available.\n\nPerfect for librarians, catalogers, or those who want to take a virtual tour.\n\n**Duration** : 20-24 hours **Deadline: ** To be negotiated"
+  },
+  {
+    "createdAt": "2014-08-28T13:23:03+00:00",
+    "name": "search-u-s-labs-and-u-s-special-districts-repos-for-open-source-mobile-code",
+    "title": "Search U.S. labs and special district repositories for open source mobile code",
+    "state": "completed",
+    "description": "**Tapas**: The [Mobile Code Sharing Catalog](http://gsa.github.io/Mobile-Code-Catalog/) contains a list of open-sourced mobile code (mobile web and/or native apps) including full applications, modular code, SDKs, and frameworks that can be re-used or re-purposed to jump start government products.  Here, agencies can access whole [frameworks for a mobile web site](http://gsa.github.io/Mobile-Code-Catalog/web_html.html), modular code to solve common problems, or [even links to complete apps](https://github.com/whitehouse/wh-app-ios) to use as a template for their own apps.\\n\\n\n\nWe need someone to help us find more mobile code to feed those agency efforts.\n\nThe person who accepts this task will search open source repositories of U.S. Labs and U.S. Special Districts who have open sourced development code (approximately 60 organizations).\n\nNo experience is necessary. We’ll show you where to look, how to search and what code we want you to find.\n\nDuration: 2-4 hrs\n\nDeadline: Completed one week after acceptance."
+  },
+  {
+    "createdAt": "2014-08-28T13:22:18+00:00",
+    "name": "be-an-open-opportunities-guest-blogger",
+    "title": "Be an Open Opportunities Guest Blogger",
+    "state": "completed",
+    "description": "**Tapas**:  [Open Opportunities](http://gsablogs.gsa.gov/dsic/category/open-opportunities/) is seeking a savvy blogger to join our team and help grow our network. Candidates must have a knack for writing and develop a comprehensive understanding of the Open Opportunities program.\\n\\n\n\nResponsibilities include:\n- \n\nSuggest or collaborate with team members on topic ideas for posts\n\n- \n\nResearch for posts, including reading other blogs, conducting short interviews, asking questions on Facebook, Twitter or LinkedIn\n\n- \n\nWrite one short (couple paragraphs) post a week on a wide range of topics that will serve as the lead-in for the Open Opportunities newsletter\n\n- \n\n1 or 2x a month take one of the newsletter posts and develop a longer story for posting on [Digitalgov](https://www.digitalgov.gov/).\n\n**Duration** : This task will take the volunteer up to 2 hours per week for 6 months. We are looking for you to write at least 3-4 posts a month. **Deadline:** TBD after accepting the task."
+  },
+  {
+    "createdAt": "2014-09-02T21:37:54+00:00",
+    "name": "help-make-government-mobile-by-recapping-a-challenges-in-mobile-web-design-webinar",
+    "title": "Help make gov mobile by recapping the \"Challenges in web design\" webinar",
+    "state": "completed",
+    "description": "**Tapas:** Make your presence at the September 10  [MobileGov Mystery: Getting Buy-in and Other Challenges In Mobile Web Implementations](https://www.digitalgov.gov/event/mobilegov-mystery-getting-buy-in-and-other-challenges-in-mobile-web-implementations/) webinar count triple! Sign up if you haven’t already, take copious notes, and tell the larger DigitalGov Community what challenges feds have had mobilizing their information for various devices.\\n\\n\n\n The  [DigitalGov.gov](http://www.digitalgov.gov/) recap does not need to be more than a couple paragraphs and the focus should be on the 3-5 key takeaways from each speaker (in this case Department of Energy, Defense Financial Accounting Service and the Department of Health and Human Services). You will have access to the transcript, any presentation materials and the speakers after the webinar to help make your recap the greatest! **Deadline:**  September 17th, 2014 **Duration** : up to 3 hours"
+  },
+  {
+    "createdAt": "2014-09-04T13:56:56+00:00",
+    "name": "analyze-govdelivery-metrics-for-the-open-opportunities-program",
+    "title": "Deep dive into GovDelivery metrics data",
+    "state": "completed",
+    "description": "**Tapas**: Help us improve the Open Opportunities program!  We need someone to take a deep dive into our GovDelivery metrics, measure the impact of our outreach efforts, and develop  steps to make our newsletter be more engaging and resonate with our audience.\\n\\nTasks include:\n\n- \n\nAnalyze all metrics including unique open rate, unique link click rate, total email opened, totaTapasl links clicked, conversion rate, engagement rate & unsubscribe rate\n\n- \n\nIdentify trends and patterns that show opportunity for growth\n\n- \n\nIdentify best practices\n\n- \n\nReview and share GovDelivery click-through data to determine elements of successful weekly email newsletters that can be replicated and apply to future marketing efforts\n\n**Duration:** 8-16 hours **Deadline** : TBD after accepting the task."
+  },
+  {
+    "createdAt": "2014-09-09T18:18:02+00:00",
+    "name": "create-an-event-widget-for-digitalgov-u",
+    "title": "Create an Event Widget for DigitalGov U",
+    "state": "completed",
+    "description": "**Tapas**: [DGU](http://www.digitalgov.gov/digitalgov-university/)’s events are accessible by an RSS feed but just sitting there it’s not doing anyone any good. So we thought it would be great if there were a widget that would pull the feed in for agency intranets and other places for easy promotion of the DGU events.   Ultimately the widget would fit in a right rail, but also be customizable. Widget should be developed around javascript or iframe for easy sharing. We can provide a word treatment / image and of course the feed.\\n\\n\n\nTask will be assigned on a first come first served basis.\n\n**Deadline** : October 1, 2014\n\n**Duration** : 8-16 hours"
+  },
+  {
+    "createdAt": "2014-09-08T20:32:04+00:00",
+    "name": "lead-a-content-modeling-adventure-at-the-structured-data-and-content-modeling-hands-on-workshop",
+    "title": "Lead a content modeling adventure at the structured data and content modeling hands on workshop",
+    "state": "completed",
+    "description": "**Tapas**: The September 16 [Open and Structured Data and Content Modeling Hands On Workshop](http://www.digitalgov.gov/event/open-and-structured-content-models-project-hands-on-workshop/) will have a “Choose Your own Structured Data and Content Modeling Adventure” program portion. Attendees will choose tasks like;\\n\\n\n\n- \n\nhow to break content elements from presentation on existing websites,\n\n- \n\nusing content elements for other presentation forms like social media,\n\n- \n\nhow to put the article and event models into a CMS and\n\n- \n\ntechnical tasks like looking at how to map the current elements to [schema.org](http://schema.org/).\n\nOnce they choose a topic, attendees will then break into groups to explore their chosen area of structured data and content modeling.\n\nWe need a few guides to lead attendees on the content modeling adventure. Some experience or at least curiosity with structured data or content modeling is needed. You will help the group work through their 30 minute content model adventure, take notes and give a 1 minute recap to the larger group about what your group did and 3 things they learned and/or challenges your adventurers faced. Once your report out is through, you'll give us your notes and you're time as guide will be over. **Deadline** : September 16th, 2014\n\n**Duration** : up to 2 hours (we can setup a walk through call if you are interested)\n\n** **"
+  },
+  {
+    "createdAt": "2014-09-08T17:06:50+00:00",
+    "name": "help-explain-structured-data-and-content-models-to-make-data-anytime-anywhere-ready",
+    "title": "Help explain structured data and content models to make data anytime, anywhere ready",
+    "state": "completed",
+    "description": "**Tapas**: Make your presence at the  September 16 [Open and Structured Content Hands On Workshop](http://www.digitalgov.gov/event/open-and-structured-content-models-project-hands-on-workshop/) invaluable to the larger DigitalGov community! While there will be a hands on portion, there will also be presentations from government individuals who are implementing the article and event models.\\n\\nWe know you will be taking copious notes and we would like you to share your insights with the larger DigitalGov Community and show how other organizations are approaching structured data and open content. The  [DigitalGov.gov](http://www.digitalgov.gov/) recap does not need to be more than a couple paragraphs and the focus should be on the 3-5 key takeaways from a speaker of your choice (slated speakers included National Public Radio, Securities and Exchange Commission and the National Cancer Institute). You will have access to any presentation materials and the speakers after the event to help write your recap. You'll send us a draft one week after the event and we'll help you hone your recap and publish it with your byline on DigitalGov.gov. **Deadline for First Draft:**  September 24th, 2014 **Duration** : up to 3 hours"
+  },
+  {
+    "createdAt": "2014-09-09T20:54:14+00:00",
+    "name": "review-10-negotiated-terms-of-service-agreements-on-digitalgov-gov",
+    "title": "Review 10  negotiated terms of service agreements on Digitalgov",
+    "state": "completed",
+    "description": "**Tapas** : Have you ever used our federal friendly [Terms of Service Agreements](http://www.digitalgov.gov/resources/negotiated-terms-of-service-agreements/)? Lots of agencies depend on the accuracy of this list and we need help cleaning up the list and making sure the information is correct.\\n\\nOnce we know you are interested, we will send you a spreadsheet of ten federal-compatible Terms of Service agreements. You will:\n\n1. Test the links.\n- \n\nProduct Links\n\n  - \n\nDoes it work?\n\n  - \n\nIs it to the product listed?\n\n    - \n\nIs it a different name?\n\n    - \n\nDoes the product still do the same thing?\n\n- \n\nTOS link\n\n  - \n\nDoes it work?\n\n  - \n\nIs the amended TOS posted on the vendors site along with their standard TOS or\n\n  - \n\nIs it a hardcopy amendment that has to be physically signed by both the agency and the vendor or\n\n  - \n\nSomething entirely different like Google+ and Amazon Appstore?\n\n2. Determine if the vendor still offers a free product or service?\n\n- \n\nAre there any limits to the “free?”\n\n  - \n\nIs it time limited?\n\n  - \n\nIs it for a single user?\n\n**Duration:** 2-4 hours **Deadline** : Two weeks after accepting the task"
+  },
+  {
+    "createdAt": "2014-09-11T21:44:13+00:00",
+    "name": "beat-writer-for-the-metrics-channel-of-the-digitalgov-platform",
+    "title": "Beat writer for the metrics channel of the DigitalGov platform",
+    "state": "completed",
+    "description": "**20%**: Measuring what matters gets results. If you’re passionate (or even just curious) about digital analytics and want to share how this data can help agencies make important DigitalGov decisions, we want you!\\n\\n\n\nThis position will make you the beat writer for the metrics channel of the [DigitalGov](http://www.digitalgov.gov/category/metrics/) platform, where we share stories of agencies using metrics across a variety of categories and channels: mobile, social media, usability, Web, competitions and prizes, code and contact centers to improve the digital services to citizens.\n\nThe person who accepts this position will be helping government digital innovators learn new and innovative ways to track their program’s impact!\n\nHere’s how it will work. Once a month you will meet with one of our community managers from one of the above categories (e.g. contact center) to research and share the meaningful metrics program managers in these areas should be investigating. Our community managers will connect you with research on metrics practices in that area, as well as members of their communities exploring these metrics questions in their agencies. Each post should include:\n\n- \n\nAn overview of metrics that are important to the featured category\n\n- \n\nExample of an agency or agencies in the community using data to affect their work in this space\n\n- \n\nLook at upcoming trends that may affect the metrics important to the community\n\n**Duration** : This task will take the volunteer up to 12 hours a month for 6 months. We’re looking for you to write 1 post a month.\n\n**Deadline** : TBD after accepting the task."
+  },
+  {
+    "createdAt": "2014-09-15T21:49:10+00:00",
+    "name": "mobilegov-guest-blogger-for-mobile-products-thursday-weekly-feature",
+    "title": "MobileGov guest blogger for “Mobile Products Thursday” weekly feature",
+    "state": "completed",
+    "description": "**[![20% of a pie.](http://gsablogs.gsa.gov/dsic/files/2013/01/pecan-pie-1.png)](http://gsablogs.gsa.gov/dsic/files/2013/01/pecan-pie-1.png)20%**: Someone to help improve mobile implementations by writing the “Mobile Products Thursday,” a weekly feature on [ DigitalGov.gov](http://digitalgov.gov/).\\n\\n\n\nEvery Thursday  [Digitalgov.gov](https://www.digitalgov.gov/) features a post on a new or updated government mobile product (responsive web design, hybrid or native apps).\n\nWe're looking for a versatile blogger who can be as creative as the topic allows (humor is always appreciated). Blogs should be written in a conversational, engaging tone and in a way that readers can hear the writer's \"voice.\" Some good examples of posts include the HHS’ [ Mobile REMM App](http://www.digitalgov.gov/2014/07/10/mobile-remm-app-new-physicians-aid/), CDC’s [ Can I Eat This? app](http://www.digitalgov.gov/2014/05/08/cdcs-new-app-answers-the-question-can-i-eat-this/) and this [ Valentine’s Day one](https://www.digitalgov.gov/2013/02/14/mobile-gov-for-valentines-day/) last year. Refer to the [ USA.gov Mobile Apps Directory](http://www.usa.gov/mobileapps.shtml) or ideas, coordinate with the MobileGov Community of Practice faciltator for other potential features on pending mobile products (app, mobile web, etc.) and write a weekly post about mobile products. You will have to check previous posts to make sure your proposed post has not been featured in the past 6 months.\n\nEach post should include a:\n\n- \n\nLink to the agency who developed the app/site\n\n- \n\nBrief description about what the app does\n\n- \n\nScreen shot of the app\n\n- \n\nLink to the app in [ USA.gov Mobile Apps Directory a](http://www.usa.gov/mobileapps.shtml)nd/or the agency’s page advertising the app\n\n**Duration** : Up to 3 hours per week and we are looking for you to write at least 3-4 posts a month for 6 months.\n\n**Deadline** : TBD after acceptance of task."
+  },
+  {
+    "createdAt": "2014-09-15T21:56:33+00:00",
+    "name": "be-an-hhs-gov-mobile-tester",
+    "title": "Be an HHS.gov mobile tester",
+    "state": "completed",
+    "description": "**Tapas**: Want to:\n- Learn more about responsively designed websites?\n- Directly contribute to making a federal website better?\n- Collaborate with other Federal Employees?\\n\\n\nGrab your mobile device and join us as we crowdsource test HHS.gov responsive website, September 29th-October 6th, 2014. No experience is necessary, just you and your mobile device (or devices.) If you are interested, include the device(s) you plan to test and their operating system(s) and versions (e.g. iPhone 5S, iOS 7.1.1) **Duration** : 2-4 hours (1 hour per mobile device, plus 1 hour to review preliminary material, and a 30 minute orientation call) **Deadline**** to sign up**: Friday, September 26th by noon."
+  },
+  {
+    "createdAt": "2014-09-17T14:53:01+00:00",
+    "name": "mobile-gov-guest-blogger-for-mobile-products-thursday",
+    "title": "Mobile Gov guest blogger for \"Mobile Products Thursday\"",
+    "state": "completed",
+    "description": "**20%**: Someone to help improve mobile implementations by writing the “Mobile Product Thursday” weekly blog post for the  [Mobile Gov Blog](http://howtomobile.apps.gov/). The blog consists of frequent, quick posts on what government is doing in mobile, general mobile news, trends in mobile use, and issues on implementing mobile for the public.\\n\\nEvery Thursday we feature a post on government mobile products. Mobile product blogs are kept simple, with a single trend. Posts should be composed in less than an hour to help keep focus on simplicity and speed. Refer to the  [USA.gov Apps Gallery](http://apps.usa.gov/) for ideas, work with Digital Services Innovation Center for features on newer mobile products (app, mobile web, etc.) and write a post about a new mobile product. You will have to check previous posts to make sure your proposed post has recently been blogged about. Each post should include a:\n- Link to the agency who developed the app/site\n- Brief description about what the app does\n- Screen shot of the app\n- Link to the app in USA.gov Apps Gallery or the agency’s page advertising the app\n**Duration: ** Up to 2 hours per week for 4-6 months **Deadline: ** TBD after accepting the task (approximate timeframe Feb/March through June/August) (Contey 2nd 20% time)"
+  },
+  {
+    "createdAt": "2014-09-18T03:50:52+00:00",
+    "name": "help-us-gamify-the-task-creation-function-of-open-opportunities",
+    "title": "Help \"gamify\" the task creation function of Open Opportunities",
+    "state": "completed",
+    "description": "**Tapas**: Open Opportunities is looking for someone to help us design a game that will increase the number of tasks created for Open Opportunities. The game should be exciting and competitive to engage people in a process that is new to them. In addition to the goal of engaging people in the process of task creation we are looking to boost the overall number of task created during the last quarter of the fiscal year.\\n\\n\n\nThe “game designer” will need to:\n- \n\nWork with us to develop the concept\n\n- \n\nCreate a theme or genre (make it competitive and exciting)\n\n- \n\nOutline the game mechanics\n\n  - \n\nWhat choices will the player make, and when will they make them?\n\n  - \n\nHow will the player make these choices?\n\n  - \n\nHow will one player's choice impact the other players?\n\n  - \n\nHow will the players interact with each other?\n\n  - \n\nAre there any choices that can be made by one player, but not by the others?\n\n  - \n\nHow does the game progress?\n\n  - \n\nWhat actions will the player be able to take?\n\n- \n\nDetermine the players goal and how they can win\n\n- \n\nIterate  the rules of the game\n\n- \n\nCreate game board, pieces and additional materials as needed\n\nThe game will run from July 1, 2014 through September 30, 2014 **Duration** :  8-16 Hours **Deadline** : June 30, 2014"
+  },
+  {
+    "createdAt": "2014-09-18T16:46:33+00:00",
+    "name": "7620",
+    "title": "Facilitate play of the\"World Domination\" game for the Digitalgov team",
+    "state": "completed",
+    "description": "**20%**: [Open Opportunities](http://gsablogs.gsa.gov/dsic/category/open-opportunities/) has created a game that will take place over the last three months of the fiscal year. The goal of the game is to engage [Digitalgov](https://www.digitalgov.gov/) staff in gaining comfort and mastery in the function of task creation.\\n\\n\n\nThe game, World Domination has been designed to be both exciting and competitive. We need someone to:\n- \n\nKeep track of everyone’s progress\n\n- \n\nFind creative ways to present the progress at weekly staff meetings\n\n- \n\nServe as dispute arbitrator and enforcer\n\n**Duration** : up to 2 hours per week over 3 months **Deadline** : September 30, 2014"
+  },
+  {
+    "createdAt": "2014-09-23T19:07:29+00:00",
+    "name": "one-photographer-to-help-socialize-techstate-mobile-diplomacy",
+    "title": "One photographer to help socialize Tech@State mobile diplomacy",
+    "state": "completed",
+    "description": "**Tapas**: We expect the [Tech@State](https://www.digitalgov.gov/2014/09/17/save-the-date-techstate-mobile-diplomacy-event/) Mobile Diplomacy to generate a lot of digital content and we want to be sure we capture the great stories as they are happening and share them.\\n\\nWe are looking for a fed to take photos at the event so we can share them on Google+, Twitter, Instagram, and Pinterest and writeups after the event. Task will be assigned on a first come first served basis. ** Deadline** : October 1, 2014 **Duration** : Up to 2 hours (in addition to attending the event)"
+  },
+  {
+    "createdAt": "2014-09-23T19:10:49+00:00",
+    "name": "one-social-media-expert-to-help-socialize-techstate-mobile-diplomacy",
+    "title": "One social media expert to help socialize Tech@State mobile diplomacy",
+    "state": "completed",
+    "description": "**Tapas**: We expect the [Tech@State](https://www.digitalgov.gov/2014/09/17/save-the-date-techstate-mobile-diplomacy-event/) Mobile Diplomacy to generate a lot of digital content and we want to be sure we capture the great stories as they are happening and share them.\\n\\n\n\nWe are looking for a fed to help us tweet on the official State Twitter and potentially other potential social media properties. The person should also retweet and share other people’s posts about the event.\n\nTask will be assigned on a first come first served basis. **Deadline** : October 1, 2014 **Duration:**  Up to 2 hours (in addition to attending the event)"
+  },
+  {
+    "createdAt": "2014-09-23T19:16:03+00:00",
+    "name": "one-video-editing-expert-to-help-produce-footage-from-techstate-mobile-diplomacy",
+    "title": "One video editing expert to help produce footage from Tech@State mobile diplomacy",
+    "state": "completed",
+    "description": "**Tapas**: We expect the [Tech@State Mobile Diplomacy ](https://www.digitalgov.gov/2014/09/17/save-the-date-techstate-mobile-diplomacy-event/)to generate a lot of digital content and we want to be sure we capture the great stories as they are happening and share them.\\n\\n\n\nWe are looking for a fed to help us edit video footage from the panels and keynotes at the event to create post event recaps.\n\nTask will be assigned on a first come first served basis. **Deadline** : October 1, 2014 **Duration:**  Up to 2 hours (in addition to attending the event)"
+  },
+  {
+    "createdAt": "2014-09-24T18:43:56+00:00",
+    "name": "focus-group-co-leader",
+    "title": "Focus group co-leader",
+    "state": "completed",
+    "description": "**Tapas**: The DigitalGov UX team is working with a government website that has produced educational videos. They are interested in getting feedback on these videos via live discussions with customers. We would like to create a focus group, or a series of user interviews, where we screen the videos and find out what people think about them.\\n\\nWe are looking for a skilled, engaging facilitator with experience leading focus groups to work with our team. Experience with video a plus. The volunteer will help plan and execute this event with us, ideally in the next 2-3 months. Volunteer must be able to come to our DC office. **Duration** : 4-8 hours **Deadline:**  TBD Once selected, you'll work with us to plan and run the event"
+  },
+  {
+    "createdAt": "2014-09-26T19:04:31+00:00",
+    "name": "prepare-a-swot-analysis-of-the-open-opportunities-program",
+    "title": "Prepare a SWOT analysis of the Open Opportunities program",
+    "state": "completed",
+    "description": "**Tapas** : Open Opportunities is looking for someone to prepare a SWOT analysis of the program. The SWOT analysis will:\\n\\n\n\n- Outline our strengths\n- Uncover opportunities\n- Help us understand our weaknesses so we\n- Manage and eliminate threats\n**Deadline** : TBD **Duration** :  4-8 hours"
+  },
+  {
+    "createdAt": "2014-09-30T15:01:47+00:00",
+    "name": "track-and-analyze-open-opportunities-performance-metrics",
+    "title": "Track and analyze Open Opportunities performance metrics",
+    "state": "completed",
+    "description": "**20%**: The Open Opportunities Program was launched over a year ago and since then we have developed a solid group of performance metrics.  We are looking for someone to be responsible for analyzing and evaluating those metrics on a monthly basis.\n\n\\n\\nSpecifically, we need someone to:\n\n- \n\nAnalyze the data, identify issues and recommend changes\n\n- \n\nEnsure accuracy of data through partnerships with team members\n\n- \n\nProvide monthly summary of stats\n\n- \n\nValidate data and do spot checks\n\nDo you like numbers? Do you have a few hours every week for the next 6 months to help us keep track of this data? If you do, let us know!\n\n**Duration:**  4-6 months from accepting the task\n\n**Deadline** :  Ongoing"
+  },
+  {
+    "createdAt": "2014-10-01T00:54:26+00:00",
+    "name": "task-for-video-script-writer",
+    "title": "Video script writer",
+    "state": "completed",
+    "description": "**Tapas**: Open Opportunities is looking for a script writer to work with the team to develop a video from the perspective of the managers who support their staff participating in Open Opportunities. It will focus on the value they see in the program and what was gained from allowing staff to participate.\\n\\n\n\nThe script writer will:\n\n- \n\nidentify the best soundbites from taped video\n\n- \n\npresent draft with soundbites in a script format\n\n- \n\nincorporate team’s feedback for final script\n\nThe ultimate goal of the script writer is to organize the video in a way that best conveys the message. **Deadline** : October 15, 2014 **Duration** : 4-8 hours"
+  },
+  {
+    "createdAt": "2014-10-01T01:49:40+00:00",
+    "name": "let-your-inner-data-detective-out-and-get-to-know-new-hampshire",
+    "title": "Let your inner \"data detective\" out and get to know New Hampshire",
+    "state": "open",
+    "description": "**Tapas**: USA.gov searches across all federal, state, and local government websites–that’s hundreds of billions of pages from .gov and .mil websites plus  [over 11,000 .com, .org, etc. websites](http://govt-urls.usa.gov/tematres).\\n\\nHere’s your chance to improve the results searchers on USA.gov see for New Hampshire and at the same time learn more about the state whose motto is \"Live Free or Die\".\n\n1. Once you let us know that you’re interested, we’ll give you access to edit the known New Hampshire websites directly:  [http://govt-urls.usa.gov/tematres/vocab/index.php?tema=43](http://govt-urls.usa.gov/tematres/vocab/index.php?tema=43)\n\n2. Your task is to visit the website for each New Hampshire city, county, and state agency.\n\n3. Review the website to make sure it still belongs to an official government agency, and add a scope note to provide some basic bibliographic information about the agency.\n\n4. If you want to try this out but can’t tackle all the links, let us know! We still want to hear from you!\n\nIf there is a another state you prefer to work on let us know.  Chances are it is still available.\n\nPerfect for librarians, catalogers, or those who want to take a virtual tour.\n\n**Duration** : 4-8 hours **Deadline: ** To be negotiated"
+  },
+  {
+    "createdAt": "2014-10-01T02:00:53+00:00",
+    "name": "let-your-inner-data-detective-out-and-get-to-know-massachusetts",
+    "title": "Let your inner \"data detective\" out and get to know Massachusetts",
+    "state": "open",
+    "description": "**Tapas**: USA.gov searches across all federal, state, and local government websites–that’s hundreds of billions of pages from .gov and .mil websites plus  [over 11,000 .com, .org, etc. websites](http://govt-urls.usa.gov/tematres).\\n\\nHere’s your chance to improve the results searchers on USA.gov see for the state of Massachusetts and learn more about the birthplace of four United States presidents: John Adams, John Quincy Adams, John Fitzgerald Kennedy and George Herbert Walker Bush.\n\n1. Once you let us know that you’re interested, we’ll give you access to edit the known Massachusetts websites directly:  [http://govt-urls.usa.gov/tematres/vocab/index.php?tema=43](http://govt-urls.usa.gov/tematres/vocab/index.php?tema=43)\n\n2. Your task is to visit the website for each Massachusetts city, county, and state agency.\n\n3. Review the website to make sure it still belongs to an official government agency, and add a scope note to provide some basic bibliographic information about the agency.\n\n4. If you want to try this out but can’t tackle all the links, let us know! We still want to hear from you!\n\nIf there is a another state you prefer to work on let us know.  Chances are it is still available.\n\nPerfect for librarians, catalogers, or those who want to take a virtual tour.\n\n**Duration** : 16-24 hours **Deadline: ** To be negotiated"
+  },
+  {
+    "createdAt": "2014-10-01T02:41:34+00:00",
+    "name": "let-your-inner-data-detective-out-and-get-to-know-rhode-island",
+    "title": "Let your inner \"data detective\" out and get to know Rhode Island",
+    "state": "completed",
+    "description": "**Tapas**: USA.gov searches across all federal, state, and local government websites–that’s hundreds of billions of pages from .gov and .mil websites plus  [over 11,000 .com, .org, etc. websites](http://govt-urls.usa.gov/tematres).\\n\\nHere’s your chance to improve the results searchers on USA.gov see for the state of Rhode Island.  Rhode Island has no county government. It is divided into 39 municipalities each having its own form of local government.\n\n1. Once you let us know that you’re interested, we’ll give you access to edit the known Rhode Island websites directly:  [http://govt-urls.usa.gov/tematres/vocab/index.php?tema=43](http://govt-urls.usa.gov/tematres/vocab/index.php?tema=43)\n\n2. Your task is to visit the website for each Rhode Island city, municipality and state agency.\n\n3. Review the website to make sure it still belongs to an official government agency, and add a scope note to provide some basic bibliographic information about the agency.\n\n4. If you want to try this out but can’t tackle all the links, let us know! We still want to hear from you!\n\nIf there is a another state you prefer to work on let us know.  Chances are it is still available.\n\nPerfect for librarians, catalogers, or those who want to take a virtual tour.\n\n**Duration** : 4-8 hours\n\n**Deadline:** TBD after task is assigned"
+  },
+  {
+    "createdAt": "2014-10-01T02:55:44+00:00",
+    "name": "let-your-inner-data-detective-out-and-get-to-know-maine",
+    "title": "Let your inner \"data detective \" out and get to know Maine",
+    "state": "open",
+    "description": "**Tapas**: USA.gov searches across all federal, state, and local government websites–that’s hundreds of billions of pages from .gov and .mil websites plus  [over 11,000 .com, .org, etc. websites](http://govt-urls.usa.gov/tematres).\\n\\nHere’s your chance to improve the results searchers on USA.gov see for the state of Maine.\n\n1. Once you let us know that you’re interested, we’ll give you access to edit the known Maine websites directly:  [http://govt-urls.usa.gov/tematres/vocab/index.php?tema=43](http://govt-urls.usa.gov/tematres/vocab/index.php?tema=43)\n\n2. Your task is to visit the website for each Maine city, municipality and state agency.\n\n3. Review the website to make sure it still belongs to an official government agency, and add a scope note to provide some basic bibliographic information about the agency.\n\n4. If you want to try this out but can’t tackle all the links, let us know! We still want to hear from you!\n\nIf there is a another state you prefer to work on let us know.  Chances are it is still available.\n\nPerfect for librarians, catalogers, or those who want to take a virtual tour.\n\n**Duration** : 4-8 hours\n\n**Deadline** : TBD after task is assigned"
+  },
+  {
+    "createdAt": "2014-10-01T03:10:06+00:00",
+    "name": "let-your-inner-data-detective-out-and-get-to-know-connecticut",
+    "title": "Let your inner \"data detective\" out and get to know Connecticut",
+    "state": "completed",
+    "description": "**Tapas**: USA.gov searches across all federal, state, and local government websites–that’s hundreds of billions of pages from .gov and .mil websites plus  [over 11,000 .com, .org, etc. websites](http://govt-urls.usa.gov/tematres).\\n\\nHere’s your chance to improve the results searchers on USA.gov see for the state of Connecticut.\n\n1. Once you let us know that you’re interested, we’ll give you access to edit the known Connecticut websites directly:  [http://govt-urls.usa.gov/tematres/vocab/index.php?tema=43](http://govt-urls.usa.gov/tematres/vocab/index.php?tema=43)\n\n2. Your task is to visit the website for each Connecticut city, municipality and state agency.\n\n3. Review the website to make sure it still belongs to an official government agency, and add a scope note to provide some basic bibliographic information about the agency.\n\n4. If you want to try this out but can’t tackle all the links, let us know! We still want to hear from you!\n\nIf there is a another state you prefer to work on let us know.  Chances are it is still available.\n\nPerfect for librarians, catalogers, or those who want to take a virtual tour.\n\n**Duration** : 16-24 hours\n\n**Deadline** : TBD after task is assigned"
+  },
+  {
+    "createdAt": "2014-10-01T03:15:04+00:00",
+    "name": "let-your-inner-data-detective-out-and-get-to-know-north-carolina",
+    "title": "Let your inner \"data detective\" out and get to know North Carolina",
+    "state": "open",
+    "description": "**Tapas**: USA.gov searches across all federal, state, and local government websites–that’s hundreds of billions of pages from .gov and .mil websites plus  [over 11,000 .com, .org, etc. websites](http://govt-urls.usa.gov/tematres).\\n\\nHere’s your chance to improve the results searchers on USA.gov see for the state of North Carolina. Take a virtual tour of the state that is \"first in freedom\" and \"first in flight\".\n\n1. Once you let us know that you’re interested, we’ll give you access to edit the known North Carolina websites directly:  [http://govt-urls.usa.gov/tematres/vocab/index.php?tema=43](http://govt-urls.usa.gov/tematres/vocab/index.php?tema=43)\n\n2. Your task is to visit the website for each North Carolina city, municipality and state agency.\n\n3. Review the website to make sure it still belongs to an official government agency, and add a scope note to provide some basic bibliographic information about the agency.\n\n4. If you want to try this out but can’t tackle all the links, let us know! We still want to hear from you!\n\nIf there is a another state you prefer to work on let us know.  Chances are it is still available.\n\nPerfect for librarians, catalogers, or those who want to take a virtual tour.\n\n**Duration** : 8-16 hours\n\n**Deadline: ** TBD when task is assigned"
+  },
+  {
+    "createdAt": "2014-10-01T15:33:58+00:00",
+    "name": "innovations-in-apis-guest-blogger-for-digitalgov-platform",
+    "title": "Innovations in APIs: Guest blogger for Digitalgov Platform",
+    "state": "completed",
+    "description": "**20%**: In order to open up data for developer use, agencies are implementing APIs. This position makes you a writer for the code channel of the  [DigitalGov](http://www.digitalgov.gov/) platform which focuses on ways agencies are releasing APIs and using code for their digital efforts. Once a week we will feature a post on an API an agency has implemented or _other useful information_. Posts should be composed in less than an hour to help keep focus on simplicity and speed.\\n\\n\n ![](https://gsablogs.gsa.gov/dsic/wp-includes/js/tinymce/plugins/wordpress/img/trans.gif \"More...\")There are a couple ways we can help you get ideas for articles: We can provide you with a link to federal APIs or you can search for API's to feature. Each post should include:\n- A link to the API\n- Explanation on why it was implemented\n- A link to creating API resource(s) on the DigitalGov platform\n\nIn addition to writing about specific agency APIs there is a robust API Google Group that you can join that has discussions that can be used for articles as well. ** **\n\n**Duration** : This task will take the volunteer up to 2 hours per week for 6 months. We are looking for you to write at least 3-4 posts a month.\n\n**Deadline** : March 31, 2015 (Bill 2nd term)"
+  },
+  {
+    "createdAt": "2014-10-01T16:19:35+00:00",
+    "name": "help-capture-the-future-of-government-service-delivery",
+    "title": "Help capture the future of government service delivery",
+    "state": "completed",
+    "description": "**Tapas**: You can help capture the conversation by taking notes during our first in-person, invite only, Research Round Table on Friday, October 17. During this two hour event, we will explore the topic “What will digital government look like in 2024? What might be the policy challenges in making it so?”\\n\\n\n\nThe trends and prognostications you capture during the Round Table will be compiled into a research brief to help agencies think about the future of government service delivery, this follows earlier work similar to the [Transforming Online Government](http://www.digitalgov.gov/files/2013/11/Federal-Web-Managers-White-Paper.pdf) published in November 2008. We plan a December publish date set to coincide with the 10th anniversary of the [first federal Web policies](http://www.whitehouse.gov/sites/default/files/omb/memoranda/fy2005/m05-04.pdf). The two spots will be assigned on a first-come, first-served basis. **Deadline** : Notes due COB, Monday, October 22 **Duration:** Up to 3 hours"
+  },
+  {
+    "createdAt": "2014-10-07T12:22:48+00:00",
+    "name": "facilitators-needed-for-round-table-discussions",
+    "title": "Facilitators needed for round table discussions",
+    "state": "completed",
+    "description": "**Tapas**: Have you helped run User Experience tests to gain meaningful feedback from testing participants or facilitated focus groups? We want your experience to help facilitate small group discussions at an invite-only fed event where we will explore the topic “What will digital government look like in 2024? What might be the policy challenges in making it so?”\\n\\n\n\nWe need your help to ensure questions are fully explored and everyone’s voices are heard. We will have note takers at the tables, so your job will be to keep the participants on topic and ensure equal participation. We are holding a Research Round Table on Friday, October 17. During this two hour event, Your facilitation will be vital to ensure insights and trends will be uncovered by the participants. This information will later be compiled into a research brief to help agencies think about the future of government service delivery. The three spots will be assigned on a first-come, first-served basis. **Duration** : Up to 3 hours, including the two hour event **Deadline** : Event held Friday, October 17, from 9:30 am-11:30 am"
+  },
+  {
+    "createdAt": "2014-10-09T19:25:59+00:00",
+    "name": "quality-assurance-qa-for-challenge-gov-pages",
+    "title": "Quality Assurance (QA) for Challenge.gov Pages",
+    "state": "completed",
+    "description": "**Tapas**: You'll be the critical eye going through the web pages to determine that pages and links are functional and to identify mistakes or potential problems\\n\\nThere are 36 web pages that list federal challenge and prize competitions, and six footer pages with instructional content. We need 7 people to go through 6 pages and do quality assurance checks on the content, links and functionality of these pages. No [Challenge.gov](https://www.challenge.gov/list/)experience is needed. In fact, it would be helpful to have people who are not familiar with challenge and prize program to do these tasks. We would also welcome feedback with suggestions for improvements. **Duration:** 2-4 hours **Deadline:** Negotiable"
+  },
+  {
+    "createdAt": "2014-10-09T20:15:43+00:00",
+    "name": "community-manager-for-open-opportunities-linkedin-group-2",
+    "title": "Community Manager for Open Opportunities LinkedIn Group",
+    "state": "completed",
+    "description": "**20%: **The Open Opportunities team is ready to take their LinkedIn community to another level and is looking for help! The goal is to build an engaged network of government innovators.  ![](https://gsablogs.gsa.gov/dsic/wp-includes/js/tinymce/plugins/wordpress/img/trans.gif \"More...\")If you have:\\n\\n\n\n- a passion for community management\n- an interest in interacting with one of the coolest communities in government\n- creative flair for developing \"small scale\" campaigns on LinkedIn\nWe want to hear from you! Some duties include:\n- sending regular announcements\n- starting and monitoring discussions\n- getting to know the members and recognize them\n- highlighting great things happening around government\n- being the face of Open Opportunities on the platform\n**Duration:**  20% time over 4-6 months **Deadline:** ongoing ** **"
+  },
+  {
+    "createdAt": "2014-10-27T14:16:20+00:00",
+    "name": "who-to-follow-on-twitter-kids-gov-wants-to-know",
+    "title": "Who should Kids.gov follow on Twitter? Curious minds want to know.",
+    "state": "completed",
+    "description": "**Tapas** :  [Kids.gov](http://www.kids.gov), the official web portal for kids, is putting together a list of influencers that the site should be following and interacting with on Twitter. \\n\\nIf you’re interested in this Tapas, all you will need to do is compile a spreadsheet with a list of 25 contacts and their Twitter handles. The list can include teachers, schools, organizations, and other educators that are active on this platform. Interested? Questions? Click on the blue button and we’ll be in touch. **Duration** : 2-4 hours **Deadline:** 2 weeks after accepting the task"
+  },
+  {
+    "createdAt": "2014-10-30T01:10:48+00:00",
+    "name": "usda-needs-you-to-help-validate-some-data",
+    "title": "USDA needs you to help validate some data",
+    "state": "completed",
+    "description": "**Tapas**: We need a few good folks to help us validate and correct bad addresses in the USDA Meat & Poultry Inspection Directory. The Directory provides 24/7 access to information on regulated establishments that produce meat, poultry, and/or egg products as regulated by USDA’s Food Safety and Inspection Service.\\n\\n [![animated image of a USDA inspector](http://gsablogs.gsa.gov/dsic/files/2014/10/USDA-inspector-image.jpg)](http://gsablogs.gsa.gov/dsic/files/2014/10/USDA-inspector-image.jpg)The Agency has a subset of addresses that need validating and correcting to ensure they can be leveraged for geospatial mapping.  Given the information provided, FSIS is looking to determine if the address meets certain requirements described below or whether an alternate address representing the same location would be more appropriate.  FSIS would like you to determine if the address is suitable as a (1) mailing address, (2) physical address, or (3) mapping address.  Ideally, these addresses would meet all three requirements, but not necessarily. We need your help investigating if the addresses meet the requirements. Here’s how you can help, once we know you’re interested:\n1. We’ll provide you with a list of 16 addresses.\n2. Make sure the address meets one or more of the 3 types of addresses listed in the description above.\n3. Include the latitude/longitude coordinates for as many of the addresses as possible.\n4. Make changes to the existing  (i.e., zip code error, misspelling or incorrect street identifier (i.e., Rd. instead of St.)) or provide alternate addresses that would represent the same location but are better to use for one or more of the criteria above.\n5. When you are done, return the completed spreadsheet with the 16 corrected addresses.\n6. **Optional:** Let us know how we can make this easier in the future - list any methods or techniques that could be used to validate and correct addresses on a larger scale in a brief 1-page or less summary of the methods or techniques.\n7. Take 16 more.....\n**Duration:** 1-2 hours **Deadline:** Task should be completed within two weeks of us providing you with the spreadsheet."
+  },
+  {
+    "createdAt": "2014-11-05T22:42:52+00:00",
+    "name": "mobilegov-guest-blogger-for-trends-on-tuesday-2",
+    "title": "MobileGov guest blogger for “Trends on Tuesday”",
+    "state": "completed",
+    "description": "**20%**: Let your federal colleagues know the latest trends in mobile adoption by writing  [“Trends on Tuesday” blog posts](http://www.digitalgov.gov/category/mobile/) for the DigitalGov Platform. ![Inline image 1](https://mail.google.com/mail/u/0/?ui=2&ik=898ad34d4e&view=att&disp=emb&realattid=ii_149821db78727d8d&zw)\\n\\nThis position makes you a writer for the mobile channel which focuses on general mobile news, trends in mobile use and agency challenges and solutions for implementing mobile products like apps, responsive web design, SMS and mobile websites for the public. Every Tuesday we feature a post on mobile user trends. Trends on Tuesday are kept simple, with a single trend. Posts should be composed in less than an hour to help keep focus on simplicity and speed.\nTo complete your Trends on Tuesday tasks, you will find Pew or other credible, nonpartisan studies of mobile use or choose from a Digital Services Innovation Center list, and write a post about the trend(s). You will also review previous Trends on Tuesday posts for sources and not to repeat previous trends. Each post should include:\n- A link to the source of the trend (article, survey, etc)\n- A chart, graph or image depicting or representative of the trend\n- A link to resource(s) on the Digital Gov platform\n- A concluding sentence about why this trend is important to government\n\n**Duration** : This task will take the volunteer up to 2 hours per week for 6 months. We are looking for you to write at least 3-4 posts a month.\n\n**Deadline** : TBD after accepting the task."
+  },
+  {
+    "createdAt": "2014-11-06T18:23:31+00:00",
+    "name": "creative-design-to-develop-training-for-the-paperwork-reduction-act",
+    "title": "Creative designer to make training for the Paperwork Reduction Act more visual and interesting!",
+    "state": "completed",
+    "description": "**Tapas**: Are you great with PowerPoint, Presi, or InfoGraphics? Do you know how to create visually engaging presentations for webinars? We are looking for individuals to help us design training modules on topics related to the Paperwork Reduction Act. Our hope is to develop several training modules in various formats to keep viewers engaged, rather than having every module be a static PowerPoint presentation and webinar.\\n\\nCurrently, we developed the content for three modules and are looking for creative individuals to help us turn the content into a stimulating training that will be hosted on DigitalGov University. Working closely with staff from OMB, the right individuals will help to establish a government wide training curriculum for the Paperwork Reduction Act! **Duration:** 15 Hours for each module **Deadline:** To be negotiated when task is assigned"
+  },
+  {
+    "createdAt": "2014-12-02T17:56:06+00:00",
+    "name": "let-your-inner-data-detective-out-and-get-to-know-arkansas",
+    "title": "Let your inner \"data detective\" out and get to know Arkansas",
+    "state": "completed",
+    "description": "**Tapas**: USA.gov searches across all federal, state, and local government websites–that’s hundreds of billions of pages from .gov and .mil websites plus  [over 11,000 .com, .org, etc. websites](http://govt-urls.usa.gov/tematres).Here’s your chance to improve the results searchers on USA.gov see for the state of Arkansas.\\n\\n\n\n1. Once you let us know that you’re interested, we’ll give you access to edit the known Arkansas websites directly:  [http://govt-urls.usa.gov/tematres/vocab/index.php?tema=43](http://govt-urls.usa.gov/tematres/vocab/index.php?tema=43)\n\n2. Your task is to visit the website for each Arkansas city, municipality and state agency.\n\n3. Review the website to make sure it still belongs to an official government agency, and add a scope note to provide some basic bibliographic information about the agency.\n\n4. If you want to try this out but can’t tackle all the links, let us know! We still want to hear from you!\n\nIf there is a another state you prefer to work on let us know.  Chances are it is still available.\n\nPerfect for librarians, catalogers, or those who want to take a virtual tour.\n\n**Duration** : 16-24 hours\n\n**Deadline** : TBD after task is assigned"
+  }
+]


### PR DESCRIPTION
This imports legacy task data from the Wordpress-based Open Opportunities site.

All imported tasks will be associated with user 1. We should change this to Lisa's profile ID as we run it on each environment.

All published, assigned, and completed timestamps are set to the date the task was created.

The associated user and timestamps can be changed by editing the task.

This gives us our best take on getting old data into the system for the admin metrics. Resolves #847 

## Running the script

First, download the export xml from the Wordpress site. Then run

```
$ ruby tools/wordpress-import/convert_xml.rb tools/wordpress-import/digitalservicesinnovationcenter.wordpress.2015-07-27.xml > tools/wordpress-import/import.json
```

to process and convert the xml to a JSON format that can be imported. (h/t to @ultrasaurus for the original version of this script).

Then run 

```
node tools/wordpress-import/import-tasks.js
```

to import the JSON tasks into the database.

After running this, we probably should delete `import.json` to slim down the repository size. It's included here now so we don't need to share the full xml file or run `convert_xml.rb` in each environment.