### PR TITLE
Include 18F analytics guild snippets

### DIFF
--- a/developer/index.html
+++ b/developer/index.html
@@ -537,5 +537,17 @@ function load() {
 
 load();
 </script>
+
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+  ga('create', 'UA-48605964-17', 'auto');
+  ga('set', 'anonymizeIp', true);
+  ga('set', 'forceSSL', true);
+  ga('send', 'pageview');
+</script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -73,5 +73,17 @@ function load() {
 
 load();
 </script>
+
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+  ga('create', 'UA-48605964-17', 'auto');
+  ga('set', 'anonymizeIp', true);
+  ga('set', 'forceSSL', true);
+  ga('send', 'pageview');
+</script>
 </body>
 </html>


### PR DESCRIPTION
In #922 @gbinal requested the addition of 18F Google Analytics snippets to the Open Opportunities application as well as the 18f-pages midas site.

This PR is for the static site hosted with 18F-pages only. It adds the supplied analytics snippet to the `index.html` page as well as the `/developer/index.html` page.

Per the issue, both use `UA-48605964-17` as their UA code.