### PR TITLE
Sort migration scripts numerically

### DIFF
--- a/tools/postgres/init.sh
+++ b/tools/postgres/init.sh
@@ -21,7 +21,7 @@ for ((i=0; i<${#FILES[@]}; i++)); do
 done
 
 # Sort file names
-SORTED=($(printf '%s\n' "${VERSIONS[@]}"|sort))
+SORTED=($(printf '%s\n' "${VERSIONS[@]}"|sort -g))
 
 # Get latest version
 LENGTH=${#SORTED[@]}


### PR DESCRIPTION
Ran into a lexical sorting problem when I added my tenth migration script, so I simply added the numeric sorting flag.