### PR TITLE
Fix Bad escaping in email subject line

### DIFF
--- a/api/notifications/volunteer.create.thanks/notification.js
+++ b/api/notifications/volunteer.create.thanks/notification.js
@@ -1,6 +1,6 @@
 module.exports = {
 
-  subject: 'Thanks for your interest in <%- task.title %>',
+  subject: 'Thanks for your interest in <%= task.title %>',
 
   to: '<%- user.username %>',
 


### PR DESCRIPTION
Subject line of email was HTML escaped. It
no longer does this.

https://github.com/18F/midas/issues/903