### PR TITLE
Define node and npm versions during builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,5 @@ sudo: false
 language: node_js
 node_js:
   - "0.10"
+before_install:
+  - "npm install npm@2.1.x -g"

--- a/package.json
+++ b/package.json
@@ -87,5 +87,9 @@
     "url": "https://github.com/18F/midas.git"
   },
   "bugs": "https://github.com/18F/midas/issues",
-  "license": "MIT"
+  "license": "MIT",
+  "engines": {
+    "node" : "0.10.x",
+    "npm": "2.1.x"
+  }
 }


### PR DESCRIPTION
Travis and our EC2 servers started failing on builds today. It looks like something is no longer compatible with npm v1.4.28. It doesn't seem to be related to new code, because the `master` branch, which passed a test a few days ago now fails without any changes.

A work-around is to just make sure builds use a more recent version of npm. This PR makes sure Travis updates npm before installing the application. And [this](https://github.com/18F/midas-cookbook/pull/37) makes sure the build server does the same.