### PR TITLE
Attachment policy

### DIFF
--- a/api/policies/attachment.js
+++ b/api/policies/attachment.js
@@ -1,0 +1,47 @@
+module.exports = function(req, res, next) {
+
+  // Admins can do anything
+  if (req.user.isAdmin) return next();
+
+  // Attachments require a task or project
+  if (req.param('taskId')) {
+
+    // Find task to check permissions
+    Task.findOne({ id: req.param('taskId') }).exec(function(err, task) {
+      if (err || !task) return res.badRequest('Error uploading file.');
+
+      // Task creators can attach to open tasks
+      if (task.userId === req.user.id && task.isOpen()) return next();
+
+      // Task volunteers can attach to assigned tasks
+      if (task.state === 'assigned') {
+        Volunteer.findOne({
+          userId: req.user.id,
+          taskId: task.id
+        }).exec(function(err, volunteer) {
+          if (volunteer) return next();
+          return res.forbidden();
+        });
+      } else {
+        return res.forbidden();
+      }
+    });
+
+  } else if (req.param('projectId')) {
+
+    ProjectOwner.find({
+      projectId: req.param('projectId')
+    }).exec(function(err, owners) {
+      if (err || !owners) return res.badRequest('Error uploading file.');
+
+      // Task creators can attach to projects
+      if (_.pluck(owners, 'userId').indexOf(req.user.id) !== -1) return next();
+      return res.forbidden();
+    });
+
+  } else {
+    return res.forbidden('Files must be attached to a task or project.');
+  }
+
+
+};

--- a/assets/js/backbone/apps/attachment/templates/attachment_show_template.html
+++ b/assets/js/backbone/apps/attachment/templates/attachment_show_template.html
@@ -1,7 +1,7 @@
 <div class="box-pad-lr border-bottom">
   <h2>
     Attachments
-    <div class="btn btn-c0 btn-sm file-add attachment-filebtn fileinput-button" style="<% if (!user) { %>display:none;<% } %>">
+    <div class="btn btn-c0 btn-sm file-add attachment-filebtn fileinput-button" style="<% if (!canAdd) { %>display:none;<% } %>">
       Add File
       <input id="attachment-fileupload" type="file" name="files[]" title="Attach Files">
     </div>

--- a/assets/js/backbone/apps/attachment/views/attachment_show_view.js
+++ b/assets/js/backbone/apps/attachment/views/attachment_show_view.js
@@ -112,7 +112,24 @@ var AttachmentShowView = Backbone.View.extend({
 
   render: function () {
     data = {
-      user: window.cache.currentUser
+      user: window.cache.currentUser,
+      canAdd:
+        // Admins
+        window.cache.currentUser.isAdmin ||
+        // Project creator
+        (this.options.target ==='project' && this.options.owner) ||
+        // Task creators for open tasks
+        (
+          this.options.target ==='task' && 
+          this.options.owner &&
+          ['open', 'assigned'].indexOf(this.options.state) !== -1
+        ) ||
+        // Participants for assigned tasks
+        (
+          this.options.target ==='task' &&
+          this.options.volunteer &&
+          this.options.state === 'assigned'
+        )
     };
     var template = _.template(ASTemplate)(data);
     this.$el.html(template);

--- a/assets/js/backbone/apps/tasks/show/controllers/task_show_controller.js
+++ b/assets/js/backbone/apps/tasks/show/controllers/task_show_controller.js
@@ -123,7 +123,9 @@ var TaskShowController = BaseView.extend({
         self.attachmentView = new AttachmentView({
           target: 'task',
           id: this.model.attributes.id,
+          state: this.model.attributes.state,
           owner: this.model.attributes.isOwner,
+          volunteer: this.model.attributes.volunteer,
           el: '.attachment-wrapper'
         }).render();
       }

--- a/config/policies.js
+++ b/config/policies.js
@@ -153,7 +153,7 @@ module.exports.policies = {
     'findOne': ['passport', 'authenticated', 'requireId'],
     'findAllByProjectId': ['passport', 'authenticated', 'requireId', 'project'],
     'findAllByTaskId': ['passport', 'authenticated', 'requireId', 'task'],
-    'create': ['passport', 'authenticated', 'requireUserId', 'addUserId'],
+    'create': ['passport', 'authenticated', 'requireUserId', 'addUserId', 'attachment'],
     'update': false,
     'destroy': ['passport', 'authenticated', 'requireUserId']
   },

--- a/test/api/sails/attachment.test.js
+++ b/test/api/sails/attachment.test.js
@@ -1,0 +1,154 @@
+var async = require('async');
+var assert = require('chai').assert;
+var conf = require('./helpers/config');
+var utils = require('./helpers/utils');
+var request;
+var task;
+var attachment = {
+    fileId: 1,
+    taskId: 1,
+    userId: 2
+  };
+
+describe('attachments:', function () {
+  before(function (done) {
+    request = utils.init();
+    Task.create({ userId: 2, state: 'draft' }).exec(function(err, t) {
+      if (err) return done(err);
+      task = t;
+      utils.logout(request, done);
+    });
+  });
+
+  describe('not logged in:', function () {
+    it('should fail', function(done) {
+      request.post({
+        url: conf.url + '/attachment',
+        json: attachment
+      }, function(err, res, body) {
+        assert.equal(res.statusCode, 403);
+        done(err);
+      });
+    });
+  });
+
+  describe('logged in:', function () {
+    before(function (done) {
+      utils.login(request, conf.defaultUser, done);
+    });
+    it('should fail', function(done) {
+      request.post({
+        url: conf.url + '/attachment',
+        json: attachment
+      }, function(err, res, body) {
+        assert.equal(res.statusCode, 403);
+        done(err);
+      });
+    });
+  });
+
+  describe('task creator, open task:', function () {
+    before(function (done) {
+      task.state = 'open';
+      task.save(done);
+    });
+    it('should pass', function(done) {
+      request.post({
+        url: conf.url + '/attachment',
+        json: attachment
+      }, function(err, res, body) {
+        assert.equal(res.statusCode, 200);
+        done(err);
+      });
+    });
+  });
+
+  describe('volunteer, open task:', function () {
+    before(function (done) {
+      async.series([
+        utils.logout.bind(this, request),
+        utils.login.bind(this, request, conf.attachmentUser)
+      ], done);
+    });
+    it('should fail', function(done) {
+      request.post({
+        url: conf.url + '/attachment',
+        json: attachment
+      }, function(err, res, body) {
+        assert.equal(res.statusCode, 403);
+        done(err);
+      });
+    });
+  });
+
+  describe('volunteer, assigned task:', function () {
+    before(function (done) {
+      Volunteer.create({ userId: 4, taskId: 1 }).exec(function(err, vol) {
+        attachment.userId = 4;
+        task.state = 'assigned';
+        task.save(done);
+      });
+    });
+    it('should pass', function(done) {
+      request.post({
+        url: conf.url + '/attachment',
+        json: attachment
+      }, function(err, res, body) {
+        assert.equal(res.statusCode, 200);
+        done(err);
+      });
+    });
+  });
+
+  describe('project non-owner:', function () {
+    it('should fail', function(done) {
+      delete attachment.taskId;
+      attachment.projectId = 1;
+      request.post({
+        url: conf.url + '/attachment',
+        json: attachment
+      }, function(err, res, body) {
+        assert.equal(res.statusCode, 403);
+        done(err);
+      });
+    });
+  });
+
+  describe('project owner:', function () {
+    before(function (done) {
+      ProjectOwner.create({ projectId: 1, userId: 4 }, done);
+    });
+    it('should pass', function(done) {
+      request.post({
+        url: conf.url + '/attachment',
+        json: attachment
+      }, function(err, res, body) {
+        assert.equal(res.statusCode, 200);
+        done(err);
+      });
+    });
+  });
+
+  describe('admin:', function () {
+    before(function (done) {
+      async.series([
+        utils.logout.bind(this, request),
+        utils.login.bind(this, request, conf.adminUser)
+      ], done);
+    });
+    it('should pass', function(done) {
+      request.post({
+        url: conf.url + '/attachment',
+        json: attachment
+      }, function(err, res, body) {
+        assert.equal(res.statusCode, 200);
+        done(err);
+      });
+    });
+  });
+
+  after(function(done) {
+    Task.destroy(1).exec(done);
+  });
+
+});

--- a/test/api/sails/helpers/config.js
+++ b/test/api/sails/helpers/config.js
@@ -11,6 +11,12 @@ module.exports = {
     'username': 'testuser@midascrowd.com',
     'password': 'MidasTestM4$'
   },
+  // for the attachment suite
+  'attachmentUser': {
+    'name': 'Attachment User',
+    'username': 'attachmentuser@midascrowd.com',
+    'password': 'MidasTestM4$'
+  },
   // for the admin test suite
   'adminUser': {
     'name': 'Admin User',

--- a/test/api/sails/task.test.js
+++ b/test/api/sails/task.test.js
@@ -80,10 +80,10 @@ describe('tasks:', function () {
     it('copy', function (done) {
       request.post({
         url: conf.url + '/task/copy',
-        body: JSON.stringify({taskId: 1})
+        body: JSON.stringify({taskId: 2})
       }, function (err, response, body) {
         body = JSON.parse(body);
-        assert.equal(body.taskId, 3);
+        assert.equal(body.taskId, 4);
         assert.equal(body.title, conf.tasks[0].title);
         done(err);
       });


### PR DESCRIPTION
This restricts file uploads to only users who have been verified in some way:

- admins
- task creators of open or assigned tasks
- task participants of assigned tasks
- project owners (not used for Open Opportunities)
- all signed in users can upload files that have no attachment (like profile photos)

The API will reject any other file upload or attachment requests. The front end selectively hides the "add attachment" button.

Tests for the API should pass.

Resolves #883 
