### PR TITLE
Only allow owners or admins to delete attachments

### DIFF
--- a/assets/js/backbone/apps/attachment/templates/attachment_item_template.html
+++ b/assets/js/backbone/apps/attachment/templates/attachment_item_template.html
@@ -5,7 +5,7 @@
   <td class="attachment-name">
     <a href="/api/file/get/<%- a.file.id %>" class="file-link" data-id="<%- a.file.id %>" download="<%- a.file.name %>">
       <%- a.file.name %>
-      <% if (user.isAdmin || owner) { %>
+      <% if ((user && user.isAdmin) || owner) { %>
       <a href="#" class="file-delete" data-id="<%- a.id %>"><i class="fa fa-remove"></i></a>
       <% } %>
       <br/>

--- a/assets/js/backbone/apps/attachment/templates/attachment_item_template.html
+++ b/assets/js/backbone/apps/attachment/templates/attachment_item_template.html
@@ -5,7 +5,7 @@
   <td class="attachment-name">
     <a href="/api/file/get/<%- a.file.id %>" class="file-link" data-id="<%- a.file.id %>" download="<%- a.file.name %>">
       <%- a.file.name %>
-      <% if (user && ((a.userId == a.userId) || owner)) { %>
+      <% if (user.isAdmin || owner) { %>
       <a href="#" class="file-delete" data-id="<%- a.id %>"><i class="fa fa-remove"></i></a>
       <% } %>
       <br/>


### PR DESCRIPTION
Per #939 any logged in users could delete any attachment on a task/opportunity.

This PR will restrict the ability to delete attachments to admin users and the users who are owners of that attachment.