### PR TITLE
Make tags links to search results

### DIFF
--- a/assets/js/backbone/apps/browse/controllers/browse_list_controller.js
+++ b/assets/js/backbone/apps/browse/controllers/browse_list_controller.js
@@ -29,7 +29,7 @@ Browse.ListController = BaseController.extend({
   initialize: function ( options ) {
     // this.options = options;
     this.target = options.target;
-    this.queryParams = options.queryParams || {};
+    this.queryParams = options.queryParams || false;
 
     this.fireUpCollection();
     this.initializeView();
@@ -72,6 +72,7 @@ Browse.ListController = BaseController.extend({
       self.collection.fetch({
         success: function (collection) {
           self.collection = collection;
+          if (_.has(self.queryParams, 'search')) return;
           self.browseMainView.renderList(self.collection.toJSON());
           if (self.target == 'profiles') {
             self.browseMainView.renderMap(self.collection.toJSON());

--- a/assets/js/backbone/apps/browse/controllers/browse_list_controller.js
+++ b/assets/js/backbone/apps/browse/controllers/browse_list_controller.js
@@ -22,7 +22,6 @@ Browse.ListController = BaseController.extend({
   events: {
     "click .link-backbone"  : linkBackbone,
     "click .project-background-image" : "showProject",
-    "click .task-box"       : "showTask",
     "click .add-project"    : "addProject",
     "click .add-opportunity": "addTask"
   },
@@ -30,9 +29,10 @@ Browse.ListController = BaseController.extend({
   initialize: function ( options ) {
     // this.options = options;
     this.target = options.target;
+    this.queryParams = options.queryParams || {};
+
     this.fireUpCollection();
     this.initializeView();
-
     this.collection.trigger('browse:' + this.target + ":fetch");
 
     this.listenTo(this.projectsCollection, "project:save:success", function (data) {
@@ -51,7 +51,8 @@ Browse.ListController = BaseController.extend({
     this.browseMainView = new BrowseMainView({
       el: "#container",
       target: this.target,
-      collection: this.collection
+      collection: this.collection,
+      queryParams: this.queryParams
     }).render();
   },
 
@@ -87,12 +88,6 @@ Browse.ListController = BaseController.extend({
     if (e.preventDefault) e.preventDefault();
     var id = $($(e.currentTarget).parents('li.project-box')[0]).data('id');
     Backbone.history.navigate('projects/' + id, { trigger: true });
-  },
-
-  showTask: function (e) {
-    if (e.preventDefault) e.preventDefault();
-    var id = $(e.currentTarget).data('id') || $($(e.currentTarget).parents('li.task-box')[0]).data('id');
-    Backbone.history.navigate('tasks/' + id, { trigger: true });
   },
 
   addProject: function (e) {

--- a/assets/js/backbone/apps/browse/templates/task_list_item.html
+++ b/assets/js/backbone/apps/browse/templates/task_list_item.html
@@ -19,7 +19,11 @@
       <div class="task-list-tags c0 task-single-overflow">
         <i class="task-list-icon-center <%- tagConfig.tags[tagType].icon %>"></i>
         <% _.each(tags[tagType], function (t, i) { %>
-          <%- t.name %><% if (i + 1 < tags[tagType].length) { %>,<% } %>
+          <% if (t.type == 'skill') { %>
+            <a href="/tasks?search=<%- t.name %>"><%- t.name %></a><% if (i + 1 < tags[tagType].length) { %>,<% } %>
+          <% } else { %>
+            <%- t.name %><% if (i + 1 < tags[tagType].length) { %>,<% } %>
+          <% } %>
         <% }); %>
       </div>
       <% } %>

--- a/assets/js/backbone/apps/browse/views/browse_main_view.js
+++ b/assets/js/backbone/apps/browse/views/browse_main_view.js
@@ -66,9 +66,16 @@ var BrowseMainView = Backbone.View.extend({
   },
 
   initializeSearch: function() {
-    var self = this;
+    var self  = this,
+        query = false;
     this.searchTerms = [];
     this.tags = [];
+
+    if (this.options.queryParams['search']) {
+      query = this.options.queryParams['search'].split('+').map(function(i) {
+        return { id: i, name: i };
+      });
+    }
 
     // figure out which tags apply
     for (var i = 0; i < TagConfig[this.options.target].length; i++) {
@@ -136,6 +143,11 @@ var BrowseMainView = Backbone.View.extend({
           e.choice.name = e.val;
         }
       });
+
+    if (query) {
+      $("#search").select2('data', query);
+      self.searchBar({});
+    }
   },
 
   submitOnEnter: function (e) {
@@ -177,7 +189,7 @@ var BrowseMainView = Backbone.View.extend({
   },
 
   searchBar: function (e) {
-    var self=this;
+    var self = this;
     if (e.preventDefault) e.preventDefault();
     // get values from select2
     var searchTerms = $("#search").select2("data");

--- a/assets/js/backbone/apps/browse/views/browse_main_view.js
+++ b/assets/js/backbone/apps/browse/views/browse_main_view.js
@@ -406,6 +406,9 @@ var BrowseMainView = Backbone.View.extend({
     $("#search-none").show();
     $(".search-clear").hide();
     this.searchExec(self.searchTerms);
+
+    if (this.options.target == 'tasks') Backbone.history.navigate('/tasks');
+    if (this.options.target == 'projects') Backbone.history.navigate('/projects');
   },
 
   cleanup: function() {

--- a/assets/js/backbone/apps/tag/show/templates/tag_item_template.html
+++ b/assets/js/backbone/apps/tag/show/templates/tag_item_template.html
@@ -1,4 +1,9 @@
-<li><%- tag.name %>
+<li>
+<% if (tag.type == 'skill') { %>
+  <a href='/tasks?search=<%- tag.name %>'><%- tag.name %></a>
+<% } else { %>
+  <%- tag.name %>
+<% } %>
 <% if ((data.isOwner || user.isAdmin) && edit) { %>
 <span class="tag-delete fa fa-times" data-id="<%- tag.id %>"></span>
 <% } %>


### PR DESCRIPTION
In order to close out #863 I made a few additions to how the list views work (also satisfies #832). With this PR the following functionality should be changed:

0. All "skill" tags should be links. This will be present on the individual opportunity/task and the individual project/working group view as well as the collection views. This is to directly close #863.
0. The link works by passing along the desired tag name in a query parameter to the respective collection. For instance, if you wanted to find all tasks that have been tagged with "javascript" you would navigate to `/tasks?search=javascript`. If you wanted "javascript" and "html" it would be `/tasks?search=javascript+html`.
0. Clearing the search filter criteria should set the URL back to the "clean" state (i.e. `/tasks`)

@dhcole this should be ready for your review when you've got some time