### PR TITLE
New Google Analytics snippet

### DIFF
--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -48,13 +48,15 @@
   <% if (sails.config.analytics && sails.config.analytics.google && sails.config.analytics.google.enabled == true) { %>
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
-     ga('create', '<%= sails.config.analytics.google.key %>', 'auto');
-     ga('send', 'pageview');
-   </script>
+      ga('create', '<%= sails.config.analytics.google.key %>', 'auto');
+      ga('set', 'anonymizeIp', true);
+      ga('set', 'forceSSL', true);
+      ga('send', 'pageview');
+    </script>
   <% } %>
 
   <% if (sails.config.analytics && sails.config.analytics.piwik && sails.config.analytics.piwik.enabled == true) { %>


### PR DESCRIPTION
Per #922 we want to update the Google Analytics snippet with a [new one from the 18F analytics guild](https://github.com/18F/analytics-standards#javascript-code-snippet). The most observable differences are:

0. Force to use `https://` for the collect call
0. `anonymizeIp` and `forceSSL` are enabled.