### PR TITLE
Fix issue with profile image update in FF

### DIFF
--- a/assets/js/backbone/apps/profiles/show/views/profile_show_view.js
+++ b/assets/js/backbone/apps/profiles/show/views/profile_show_view.js
@@ -202,7 +202,8 @@ var ProfileShowView = Backbone.View.extend({
   updatePhoto: function () {
     var self = this;
     this.model.on("profile:updatedPhoto", function (data) {
-      var url = '/api/user/photo/' + data.attributes.id;
+      //added timestamp to URL to force FF to reload image from server
+      var url = '/api/user/photo/' + data.attributes.id + "?" + new Date().getTime();
       // force the new image to be loaded
       $.get(url, function (data) {
         $("#project-header").css('background-image', "url('" + url + "')");


### PR DESCRIPTION
Firefox seems to be caching the first image and not
retrieving the new image when the  CSS is bumped.
Probably because the URL to the image never changes
(for example /api/user/photo/13).
My solution was to put a timestamp as a URL parameter when
retrieving the new image, (ie. /api/user/photo/13?1439337665153).
I believe this busts FF image cache, and forces FF to
get the newly uploaded image.

https://github.com/18F/midas/issues/800