### PR TITLE
Fix for long link breaks task template

### DIFF
--- a/assets/styles/application.css
+++ b/assets/styles/application.css
@@ -1468,7 +1468,7 @@ ul.task-tags > li {
   font-size: 18px;
   margin-bottom: 10px;
   line-height: 1.5em;
-  overflow: hidden;
+  word-break: break-all;
 }
 
 .task-edit-description {

--- a/assets/styles/application.css
+++ b/assets/styles/application.css
@@ -1468,6 +1468,7 @@ ul.task-tags > li {
   font-size: 18px;
   margin-bottom: 10px;
   line-height: 1.5em;
+  overflow: hidden;
 }
 
 .task-edit-description {


### PR DESCRIPTION
Added overflow: hidden to div.task-show-description

https://github.com/18F/midas/issues/944