### PR TITLE
added completedBy column to the current schema

### DIFF
--- a/tools/postgres/schema/current.sql
+++ b/tools/postgres/schema/current.sql
@@ -811,6 +811,7 @@ CREATE TABLE task (
     "projectId" integer,
     title text,
     description text,
+    "completedBy" timestamp with time zone,
     "publishedAt" timestamp with time zone,
     "assignedAt" timestamp with time zone,
     "completedAt" timestamp with time zone,


### PR DESCRIPTION
The `9.sh` migration script added the column `completedBy`, but this was never added to the `current.sql` schema. This will lead to errors such as:

`Details:  error: column task.completedBy does not exist`

if the user is setting up Midas on a fresh database.