### PR TITLE
More time intervals for task metrics

### DIFF
--- a/assets/js/backbone/apps/admin/templates/admin_dashboard_task_metrics.html
+++ b/assets/js/backbone/apps/admin/templates/admin_dashboard_task_metrics.html
@@ -1,42 +1,49 @@
-<div class="row"><div class="col-md-12">
+<div class="row"><div class="col-md-12 form-inline text-right">
+  <label for="group">Period:</label>
+  <select name="group" class="group form-control">
+    <option value="week">Week</option>
+    <option value="month">Month</option>
+    <option value="quarter">Quarter</option>
+    <option value="year">Year</option>
+    <option value="fyquarter">Fiscal Quarter</option>
+    <option value="fy">Fiscal Year</option>
+  </select>
+</div></div>
+
+<div class="row overflow-x"><div class="col-md-12">
   <table class="table task-metrics-table">
     <thead>
       <tr>
         <th scope="col">Completed Opportunities</th>
-        <% _.each(fiscalYears, function(fy) { %>
-        <th scope="col">FY<%- fy %></th>
+        <% _.each(range, function(key) { %>
+        <th scope="col"><%- label(key) %></th>
         <% }); %>
-        <th scope="col">Goal</th>
       </tr>
     </thead>
     <tbody>
       <tr>
         <th scope="row">Carryover <small>(still published or assigned)</small></th>
-        <% _.each(fiscalYears, function(fy) { %>
-        <td><%- tasks.carryOver[fy] || 0 %></td>
+        <% _.each(range, function(key) { %>
+        <td><%- tasks.carryOver[key] || 0 %></td>
         <% }); %>
-        <td></td>
       </tr>
       <tr>
         <th scope="row">Published</th>
-        <% _.each(fiscalYears, function(fy) { %>
-        <td><%- tasks.published[fy] || 0 %></td>
+        <% _.each(range, function(key) { %>
+        <td><%- tasks.published[key] || 0 %></td>
         <% }); %>
-        <td></td>
       </tr>
       <tr>
         <th scope="row">Completed</th>
-        <% _.each(fiscalYears, function(fy) { %>
-          <td><%- tasks.completed[fy] || 0 %></td>
+        <% _.each(range, function(key) { %>
+          <td><%- tasks.completed[key] || 0 %></td>
         <% }); %>
-        <td></td>
       </tr>
       <tr class="small">
         <th scope="row">Percentage Completed</th>
-        <% _.each(fiscalYears, function(fy) { %>
-        <td><%- Math.round(tasks.completed[fy] / tasks.published[fy] * 100, 4) || 0 %>%</td>
+        <% _.each(range, function(key) { %>
+        <td><%- Math.round(tasks.completed[key] / tasks.published[key] * 100, 4) || 0 %>%</td>
         <% }); %>
-        <td></td>
       </tr>
       <!-- We don't track the date a task was archived
       <tr>
@@ -102,47 +109,43 @@
 </div></div>
 -->
 
-<div class="row"><div class="col-md-12">
+<div class="row overflow-x"><div class="col-md-12">
   <table class="table task-metrics-table">
     <thead>
       <tr>
         <th scope="col">Participants</th>
-        <% _.each(fiscalYears, function(fy) { %>
-        <th scope="col">FY<%- fy %></th>
+        <% _.each(range, function(key) { %>
+        <th scope="col"><%- label(key) %></th>
         <% }); %>
-        <th scope="col"></th>
       </tr>
     </thead>
     <tbody>
       <tr>
         <th scope="row">Participants <small>(people who have signed up for tasks)</small></th>
-        <% _.each(fiscalYears, function(fy) { %>
-        <td><%- volunteers[fy] || 0 %></td>
+        <% _.each(range, function(key) { %>
+        <td><%- volunteers[key] || 0 %></td>
         <% }); %>
-        <td></td>
       </tr>
     </tbody>
   </table>
 </div></div>
 
-<div class="row"><div class="col-md-12">
+<div class="row overflow-x"><div class="col-md-12">
   <table class="table task-metrics-table">
     <thead>
       <tr>
         <th scope="col">Agencies</th>
-        <% _.each(fiscalYears, function(fy) { %>
-        <th scope="col">FY<%- fy %></th>
+        <% _.each(range, function(key) { %>
+        <th scope="col"><%- label(key) %></th>
         <% }); %>
-        <th scope="col"></th>
       </tr>
     </thead>
     <tbody>
       <tr>
         <th scope="row">Agencies <small>(with people who have signed up for tasks)</small></th>
-        <% _.each(fiscalYears, function(fy) { %>
-        <td><%- agencies[fy] || 0 %></td>
+        <% _.each(range, function(key) { %>
+        <td><%- agencies[key] || 0 %></td>
         <% }); %>
-        <td></td>
       </tr>
     </tbody>
   </table>

--- a/assets/js/backbone/apps/admin/views/admin_dashboard_view.js
+++ b/assets/js/backbone/apps/admin/views/admin_dashboard_view.js
@@ -59,6 +59,7 @@ var AdminDashboardView = Backbone.View.extend({
                   'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
 
     function label(key) {
+      if (key === 'undefined') return 'No date';
       return group === 'week' ? 'W' + (+key.slice(4)) + '\n' + key.slice(0,4):
         group === 'month' ? months[key.slice(4) - 1]  + '\n' + key.slice(0,4) :
         group === 'quarter' ? 'Q' + (+key.slice(4)) + '\n' + key.slice(0,4) :

--- a/assets/js/backbone/apps/admin/views/admin_dashboard_view.js
+++ b/assets/js/backbone/apps/admin/views/admin_dashboard_view.js
@@ -13,6 +13,7 @@ var marked = require('marked');
 var AdminDashboardView = Backbone.View.extend({
 
   events: {
+    'change .group': 'renderTasks'
   },
 
   initialize: function (options) {
@@ -50,13 +51,36 @@ var AdminDashboardView = Backbone.View.extend({
     self.$(".metric-block").show();
   },
 
-  renderTasks: function(self, data) {
-    var template = _.template(AdminDashboardTasks)(data);
-    self.$(".task-metrics").html(template);
-    this.$el.i18n();
-    // hide spinner and show results
-    self.$(".spinner").hide();
-    self.$(".task-metrics").show();
+  renderTasks: function() {
+    var self = this,
+        data = this.data,
+        group = this.$('.group').val() || 'fy',
+        months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+                  'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+    function label(key) {
+      return group === 'week' ? 'W' + (+key.slice(4)) + '\n' + key.slice(0,4):
+        group === 'month' ? months[key.slice(4) - 1]  + '\n' + key.slice(0,4) :
+        group === 'quarter' ? 'Q' + (+key.slice(4)) + '\n' + key.slice(0,4) :
+        group === 'fyquarter' ? 'Q' + (+key.slice(4)) + '\nFY' + key.slice(0,4) :
+        group === 'fy' ? 'FY' + key : key;
+    }
+
+    $.ajax({
+      url: '/api/admin/taskmetrics?group=' + group,
+      dataType: 'json',
+      success: function (data) {
+        data.label = label;
+        var template = _.template(AdminDashboardTasks)(data);
+        data.tasks.active = self.data.tasks;
+        self.$(".task-metrics").html(template);
+        self.$el.i18n();
+        // hide spinner and show results
+        self.$(".spinner").hide();
+        self.$(".task-metrics").show();
+        self.$('.group').val(group);
+      }
+    });
   },
 
   renderActivities: function (self, data) {
@@ -93,6 +117,7 @@ var AdminDashboardView = Backbone.View.extend({
     // hide spinner and show results
     self.$(".spinner").hide();
     self.$(".activity-block").show();
+    self.renderTasks(self, this.data);
   },
 
   fetchData: function (self, data) {
@@ -110,14 +135,6 @@ var AdminDashboardView = Backbone.View.extend({
               return sum + value;
             }, 0);
             self.renderMetrics(self, data);
-          }
-        });
-        $.ajax({
-          url: '/api/admin/taskmetrics',
-          dataType: 'json',
-          success: function (data) {
-            data.tasks.active = self.data.tasks;
-            self.renderTasks(self, data);
           }
         });
       }

--- a/assets/styles/application.css
+++ b/assets/styles/application.css
@@ -60,6 +60,13 @@ input {
   padding: 0 0 0 5px;
 }
 
+.overflow-x {
+  overflow-x: auto;
+}
+.overflow-x th {
+  white-space: pre-line;
+}
+
 /* Override bootstrap's .row margins for mobile & tablet */
 @media (max-width: 978px) {
   .row {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "bootstrap-datetimepicker": "https://github.com/Eonasdan/bootstrap-datetimepicker/archive/v2.1.30.tar.gz",
     "browserify": "^9.0.3",
     "chai": "2.1.2",
-    "connect-pg-simple": "^2.2.1",
+    "connect-pg-simple": "^3.0.1",
     "d3": "^3.5.5",
     "topojson": "^1.6.19",
     "ejs": "0.8.5",


### PR DESCRIPTION
This adds support on the admin dashboard for several additional time intervals, in addition to Fiscal Year, as previously supported:

<img width="671" alt="screen shot 2015-08-13 at 12 56 07 pm" src="https://cloud.githubusercontent.com/assets/170641/9255988/d8ee8750-41ba-11e5-83a1-80b746d2a834.png">

<img width="668" alt="screen shot 2015-08-13 at 12 57 13 pm" src="https://cloud.githubusercontent.com/assets/170641/9255991/dac0bcce-41ba-11e5-9f0a-915316ca7998.png">

The `undefined` column are tasks with missing dates. Since we started tracking `completedAt`, `publishedAt` and `assignedAt` after the initial launch of the platform, some tasks do not have these dates defined.

Resolves #905