### PR TITLE
Update "Ongoing" tag in the new task view

### DIFF
--- a/assets/js/backbone/apps/tasks/new/views/task_form_view.js
+++ b/assets/js/backbone/apps/tasks/new/views/task_form_view.js
@@ -52,7 +52,7 @@ var TaskFormView = Backbone.View.extend({
               if (item.name == 'One time') {
                 item.description = 'A one time task with a defined timeline'
               }
-              else if (item.name == 'On going') {
+              else if (item.name == 'Ongoing') {
                 item.description = 'Requires a portion of participant’s time until a goal is reached'
               }
               return item;


### PR DESCRIPTION
We updated the "On going" tag to be "Ongoing" but part of the new task creation view did a string match to provide the user with additional context.

This simply changes that expected string to match the new tag in the database.

Reported by @dhcole in Slack: https://18f.slack.com/archives/midas-public/p1439908358000797