### PR TITLE
Add populateFast hook for fast many-to-many associations

### DIFF
--- a/api/hooks/populateFast/index.js
+++ b/api/hooks/populateFast/index.js
@@ -1,0 +1,113 @@
+/*
+ * A faster way to populate many-to-many associations
+ *
+ * Optionally overrides Model.populate() with a faster query
+ * for manty-to-many associations. This only works on SQL-based adapters.
+ *
+ * To use, set `populateFast: true` on your connection's configuration:
+ *
+ * `config/connections.js:`
+ * module.exports = {
+ *   postgresql: {
+ *     adapter: 'sails-postgresql',
+ *     populateFast: true
+ *   }
+ * };
+ *
+ */
+
+var Deferred = require('sails/node_modules/waterline/lib/waterline/query/deferred'),
+    normalize = require('sails/node_modules/waterline/lib/waterline/utils/normalize');
+
+// Format from https://github.com/rhpwn/sails-hook-populate-fields
+module.exports = function(sails) {
+
+  function patch() {
+    Deferred.prototype.populateOriginal = Deferred.prototype.populate;
+    Deferred.prototype.execOriginal = Deferred.prototype.exec;
+    Deferred.prototype.exec = exec;
+    Deferred.prototype.populate = populateFast;
+  }
+
+  return {
+    initialize: function(done) {
+      var eventsToWaitFor = [];
+      if (sails.hooks.orm) {
+        eventsToWaitFor.push('hook:orm:loaded');
+      }
+      if (sails.hooks.pubsub) {
+        eventsToWaitFor.push('hook:pubsub:loaded');
+      }
+      sails.after(eventsToWaitFor, function() {
+        patch();
+        done();
+      });
+    }
+  };
+};
+
+function populateFast(attr) {
+  var Model = this._context,
+      schema = Model._attributes[attr],
+      connection = Model.adapter.dictionary.identity,
+      connectionConfig = Model.connections[connection].config;
+
+  if (!connectionConfig.populateFast || !schema || !schema.dominant) {
+    return this.populateOriginal.apply(this, arguments);
+  }
+
+  this._populateFast = attr;
+  return this;
+}
+
+function exec(cb) {
+  if (!this._populateFast) return this.execOriginal.apply(this, arguments);
+
+  if (!cb) {
+    console.log(new Error('Error: No Callback supplied, you must define a callback.').message);
+    return;
+  }
+
+  // Normalize callback/switchback
+  this._cb = normalize.callback(cb);
+
+  // Set up arguments + callback
+  var args = [this._criteria, populate.bind(this)];
+  if (this._values) args.splice(1, 0, this._values);
+
+  // Pass control to the adapter with the appropriate arguments.
+  this._method.apply(this._context, args);
+}
+
+function populate(err, models) {
+  if (err) return this._cb(err);
+  var Model = this._context,
+      attr = this._populateFast,
+      type = Model.identity,
+      done = this._cb,
+      assoc = _.findWhere(Model.associations, { alias: attr }),
+      table = Model.adapter.collection,
+      collection = assoc.collection,
+      via = assoc.via,
+      tagKey = collection + '_' + via, // e.g. tagentity
+      typeKey = type + '_' + attr, // e.g. tasks
+      joinTable = [tagKey, typeKey].sort().join('__'),
+      query;
+
+  query = 'SELECT tag.*, ' + table + '.id AS _model FROM ' + collection + ' tag ' +
+    'INNER JOIN ' + joinTable + ' t ON tag.id = t.' + tagKey + ' ' +
+    'INNER JOIN ' + table + ' ON ' + table + '.id = t.' + typeKey;
+
+  Model.query(query, function(err, result) {
+    if (err) return done(err);
+    var tags = result.rows,
+        groups = _.groupBy(tags, '_model'),
+        match = function (model) {
+          if (typeof model.toObject === 'function') model = model.toObject();
+          model[attr] = groups[model.id];
+          return model;
+        };
+    models = models.length ? models.map(match) : match(models);
+    return done(null, models);
+  });
+}

--- a/config/connections.js
+++ b/config/connections.js
@@ -41,7 +41,8 @@ module.exports.connections = {
     user        : 'midas',
     password    : 'midas',
     database    : 'midas',
-    softDelete  : true
+    softDelete  : true,
+    populateFast: true
   }
 
 };


### PR DESCRIPTION
This conditionally replaces the standard `Model.populate()` method with one that's up to ***11 times*** faster. It generates a much simpler SQL query for retrieving associated data from many-to-many relationships.

This solution is implemented as a hook, so it could be spun out into it's own npm module for use on any Sails application. It's generic and gets all of its settings from the standard `populate` method.

To use, set `populateFast: true` on your connection's configuration:

 `config/connections.js:`
 ```js
module.exports = {
   postgresql: {
     adapter: 'sails-postgresql',
     populateFast: true
   }
};
```

Since it uses a SQL query, it will only work with adapters that support SQL.

Here are two (previously) slow pages:

## Before

<img width="1130" alt="screen shot 2015-08-19 at 6 30 06 pm" src="https://cloud.githubusercontent.com/assets/170641/9370836/7fe96dfa-46a1-11e5-91d0-170593fbf033.png">

<img width="1130" alt="screen shot 2015-08-19 at 6 28 58 pm" src="https://cloud.githubusercontent.com/assets/170641/9370838/82b44c8a-46a1-11e5-8f4f-e5683dae4d16.png">


## After

<img width="1130" alt="screen shot 2015-08-19 at 6 27 22 pm" src="https://cloud.githubusercontent.com/assets/170641/9370845/8a7821b2-46a1-11e5-84c7-13d4bbd935f5.png">

<img width="1130" alt="screen shot 2015-08-19 at 6 27 47 pm" src="https://cloud.githubusercontent.com/assets/170641/9370849/8d72a932-46a1-11e5-89cc-5cdd60dd184a.png">


Refs #797 
Refs balderdashy/waterline#944

h/t to @sefk for doing the investigative work into why populated queries were so slow.

For sake of comparison, here are the original (standard Sails / waterline) and new queries: https://gist.github.com/dhcole/5455c7723ef968820c2a