### PR TITLE
Fix user export error

### DIFF
--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -375,6 +375,7 @@ module.exports = {
     User.find().populate('tags').exec(function (err, users) {
 
       users.forEach(function(user) {
+        if (!user.tags) return;
         user.tags.forEach(function(tag) {
           user[tag.type] = tag.name;
         });


### PR DESCRIPTION
There was an uncaught error in the export process for users without tags. This fixes it by not trying to iterate over missing tags. 

Fixes #985

Patched on production to enable exports.