### PR TITLE
Fix theme collision with new dashboard

### DIFF
--- a/assets/js/backbone/apps/home/views/home_dashboard_view.js
+++ b/assets/js/backbone/apps/home/views/home_dashboard_view.js
@@ -33,7 +33,6 @@ var DashboardView = Backbone.View.extend({
         tasks           = new TaskCollection();
 
     this.$el.html(templates.main());
-    this.$el.addClass('home');
 
     this.listenTo(badges, 'activity:collection:fetch:success', function (e) {
       var data = { badges: e.toJSON() },


### PR DESCRIPTION
The theme was clashing with our new dashboard to make it look like this:
![](https://s3.amazonaws.com/f.cl.ly/items/3G3X271c0M3D1m253b2g/Screen%20Shot%202015-09-17%20at%202.43.18%20PM.png)

The culprit was the `.home` class that was still being applied to the dashboard container. I removed the class from the view's render code to ensure that the class is only used for the unauthenticated page.

I wasn't able to get the themes to properly apply locally but I was able to test the removal of this class with Chrome dev tools to yield this:
![](https://s3.amazonaws.com/f.cl.ly/items/2k1I2M2A0834300V1l44/Screen%20Shot%202015-09-17%20at%202.45.09%20PM.png)

@dhcole I believe this is ready for review.