### PR TITLE
Add participant table for admins. Includes export csv

### DIFF
--- a/api/controllers/AdminController.js
+++ b/api/controllers/AdminController.js
@@ -792,7 +792,7 @@ module.exports = {
         });
 
       } else {
-        res.json(vols);  
+        res.json(vols);
       }
     });
   },

--- a/assets/js/backbone/apps/admin/templates/admin_main_template.html
+++ b/assets/js/backbone/apps/admin/templates/admin_main_template.html
@@ -20,6 +20,7 @@
           <li><a href="/admin/users" class="link-admin" data-target="user">User Management</a></li>
           <li><a href="/admin/tags" class="link-admin" data-target="tag">Tag Configuration</a></li>
           <li><a href="/admin/tasks" class="link-admin" data-target="tasks">Tasks</a></li>
+          <li><a href="/admin/participants" class="link-admin" data-target="participants">Participants</a></li>
         </ul>
       </div><!-- /.navbar-collapse -->
     </nav>
@@ -31,6 +32,8 @@
     <div class="admin-container" id="admin-tag">
     </div>
     <div class="admin-container" id="admin-task">
+    </div>
+    <div class="admin-container" id="admin-participants">
     </div>
     <div class="admin-container" id="admin-dashboard">
     </div>

--- a/assets/js/backbone/apps/admin/templates/admin_main_template.html
+++ b/assets/js/backbone/apps/admin/templates/admin_main_template.html
@@ -34,6 +34,9 @@
     <div class="admin-container" id="admin-task">
     </div>
     <div class="admin-container" id="admin-participants">
+      <div class="fullwidth text-center spinner">
+        Loading... <i class="fa fa-spinner fa-spin"></i>
+      </div>
     </div>
     <div class="admin-container" id="admin-dashboard">
     </div>

--- a/assets/js/backbone/apps/admin/templates/admin_participants_template.html
+++ b/assets/js/backbone/apps/admin/templates/admin_participants_template.html
@@ -3,7 +3,7 @@
 <div class="row">
   <div class="col-md-12 box box-pad-lr">
     <div class="row">
-      <div class="export-button pull-left tip" data-toggle="tooltip" data-placement="bottom"
+      <div class="export-button pull-right tip" data-toggle="tooltip" data-placement="bottom"
            title="Download list of all participants as a comma-separated file ready for import into Excel">
         <a href="/api/admin/participants?export=true">
           <i class="fa fa-download"></i>

--- a/assets/js/backbone/apps/admin/templates/admin_participants_template.html
+++ b/assets/js/backbone/apps/admin/templates/admin_participants_template.html
@@ -1,0 +1,46 @@
+<div class="alert alert-danger" style="display:none;">
+</div>
+<div class="row">
+  <div class="col-md-12 box box-pad-lr">
+    <div class="row">
+      <div class="export-button pull-left tip" data-toggle="tooltip" data-placement="bottom"
+           title="Download list of all participants as a comma-separated file ready for import into Excel">
+        <a href="/api/admin/participants?export=true">
+          <i class="fa fa-download"></i>
+        </a>
+      </div>
+
+    </div>
+    <div class="row overflow-x">
+      <div class="col-md-12">
+
+        <table class="table table-hover table-condensed">
+          <thead>
+            <tr>
+              <% _.each(data[0], function(value, key) { %>
+              <th><%- key %></th>
+              <% }); %>
+            </tr>
+          </thead>
+          <tbody>
+            <% if (data.length === 0) { %>
+            <tr class="empty-row">
+              <td colspan="<%- data[0].length %>">
+                No users found.
+              </td>
+            </tr>
+            <% } %>
+            <% _.each(data, function(row) { %>
+            <tr>
+              <% _.each(row, function(value) { %>
+                <td><%- value %></td>
+              <% }); %>
+            </tr>
+            <% }); %>
+          </tbody>
+        </table>
+
+      </div>
+    </div>
+  </div>
+</div>

--- a/assets/js/backbone/apps/admin/templates/admin_task_template.html
+++ b/assets/js/backbone/apps/admin/templates/admin_task_template.html
@@ -53,6 +53,7 @@
                 <li>
                   <a href="/tasks/<%- task.id %>"><%- task.title %></a>,
                   <a href="/profile/<%- task.user.id %>"><%- task.user.name || task.user.username %></a>
+                  <a href="#delete/<%- task.id %>" data-task-id="<%- task.id %>" data-task-title="<%- task.title %>" class="delete-task"><span class='fa fa-times'></span></a>
                   <% if (task.volunteers.length) { %>
                   <p>Sign-ups:
                     <% _(task.volunteers).forEach(function(vol) { %>

--- a/assets/js/backbone/apps/admin/views/admin_main_view.js
+++ b/assets/js/backbone/apps/admin/views/admin_main_view.js
@@ -5,6 +5,7 @@ var utils = require('../../../mixins/utilities');
 var AdminUserView = require('./admin_user_view');
 var AdminTagView = require('./admin_tag_view');
 var AdminTaskView = require('./admin_task_view');
+var AdminParticipantsView = require('./admin_participants_view');
 var AdminDashboardView = require('./admin_dashboard_view');
 var AdminMainTemplate = require('../templates/admin_main_template.html');
 
@@ -54,6 +55,12 @@ var AdminMainView = Backbone.View.extend({
       }
       this.hideOthers();
       this.adminTaskView.render();
+    } else if (target == 'participants') {
+      if (!this.adminParticipantsView) {
+        this.initializeAdminParticipantsView();
+      }
+      this.hideOthers();
+      this.adminParticipantsView.render();
     } else if (target == 'dashboard') {
       if (!this.adminDashboardView) {
         this.initializeAdminDashboardView();
@@ -97,6 +104,15 @@ var AdminMainView = Backbone.View.extend({
     }
     this.adminTaskView = new AdminTaskView({
       el: "#admin-task"
+    });
+  },
+
+  initializeAdminParticipantsView: function () {
+    if (this.adminParticipantsView) {
+      this.adminParticipantsView.cleanup();
+    }
+    this.adminParticipantsView = new AdminParticipantsView({
+      el: "#admin-participants"
     });
   },
 

--- a/assets/js/backbone/apps/admin/views/admin_participants_view.js
+++ b/assets/js/backbone/apps/admin/views/admin_participants_view.js
@@ -19,6 +19,9 @@ var AdminParticipantsView = Backbone.View.extend({
 
   render: function () {
     var self = this;
+
+    this.$el.show();
+
     $.ajax({
       url: '/api/admin/participants',
       data: this.data,
@@ -28,7 +31,6 @@ var AdminParticipantsView = Backbone.View.extend({
               variable: 'data'
             })(data);
         self.$el.html(template);
-        self.$el.show();
         $('.tip').tooltip();
       }
     });

--- a/assets/js/backbone/apps/admin/views/admin_participants_view.js
+++ b/assets/js/backbone/apps/admin/views/admin_participants_view.js
@@ -1,0 +1,46 @@
+
+var _ = require('underscore');
+var Backbone = require('backbone');
+var utils = require('../../../mixins/utilities');
+var AdminParticipantsTemplate = require('../templates/admin_participants_template.html');
+
+
+var AdminParticipantsView = Backbone.View.extend({
+
+  events: {
+  },
+
+  initialize: function (options) {
+    this.options = options;
+    this.data = {
+      page: 1
+    };
+  },
+
+  render: function () {
+    var self = this;
+    $.ajax({
+      url: '/api/admin/participants',
+      data: this.data,
+      dataType: 'json',
+      success: function (data) {
+        var template = _.template(AdminParticipantsTemplate, {
+              variable: 'data'
+            })(data);
+        self.$el.html(template);
+        self.$el.show();
+        $('.tip').tooltip();
+      }
+    });
+
+    Backbone.history.navigate('/admin/participants');
+    return this;
+  },
+
+  cleanup: function () {
+    removeView(this);
+  }
+
+});
+
+module.exports = AdminParticipantsView;

--- a/assets/js/backbone/apps/admin/views/admin_task_view.js
+++ b/assets/js/backbone/apps/admin/views/admin_task_view.js
@@ -8,6 +8,7 @@ var AdminTaskTemplate = require('../templates/admin_task_template.html');
 var AdminTaskView = Backbone.View.extend({
 
   events: {
+    'click .delete-task': 'deleteTask'
   },
 
   initialize: function (options) {
@@ -33,6 +34,21 @@ var AdminTaskView = Backbone.View.extend({
 
     Backbone.history.navigate('/admin/tasks');
     return this;
+  },
+
+  deleteTask: function(e) {
+    var view = this,
+        id = $(e.currentTarget).data('task-id'),
+        title = $(e.currentTarget).data('task-title');
+    e.preventDefault();
+    if (window.confirm('Are you sure you want to delete "' + title + '"?')) {
+      $.ajax({
+        url: '/api/task/' + id,
+        type: 'DELETE'
+      }).done(function() {
+        view.render();
+      });
+    }
   },
 
   cleanup: function () {


### PR DESCRIPTION
This adds a participants section to the admin reports with a table of all task participants and fields specified by @LisaLNelson:

- Participant
- Participant Agency
- Task Title
- Task Categories
- Task Type
- Task Status
- Task Location
- Task Creator
- Task Creator Agency
- Task Date Published
- Task Date Completed
- Task Date Closes

It also includes a CSV download option.

![screen shot 2015-09-22 at 6 48 28 pm](https://cloud.githubusercontent.com/assets/170641/10033938/8d713d08-615a-11e5-97bf-9897106f733d.png)

Resolves #973
Resolves #963

