### PR TITLE
Use tasks in 'open' state to calculate large task count

### DIFF
--- a/assets/js/backbone/apps/home/views/home_dashboard_view.js
+++ b/assets/js/backbone/apps/home/views/home_dashboard_view.js
@@ -49,7 +49,7 @@ var DashboardView = Backbone.View.extend({
     tasks.fetch({
       success: function (collection) {
         var open = collection.filter(function(t) {
-          return t.attributes.state !== 'completed';
+          return t.attributes.state === 'open';
         });
         self.$('#opportunity-count span')
             .addClass('loaded')


### PR DESCRIPTION
The task/opportunity count on the dashboard can show a number much higher than the number of open tasks. Previously we were using any task that wasn't in the 'completed' state, but now we are ONLY using tasks that are in the 'open' state.

To fix #1014