### PR TITLE
Completed tasks should be displayed on profile view

### DIFF
--- a/assets/js/backbone/apps/profiles/show/templates/profile_activity_template.html
+++ b/assets/js/backbone/apps/profiles/show/templates/profile_activity_template.html
@@ -1,7 +1,7 @@
 <div class="tab-content">
   <div class="tab-pane active" id="<%- handle %>-tab-open">
     <table class="table table-condensed table-hover">
-      <% if ( count.open > 0 || count.assigned > 0 || count.draft > 0) { %>
+      <% if ( count.open > 0 || count.assigned > 0 || count.draft > 0 || count.completed > 0) { %>
         <thead>
           <tr>
             <th data-i18n="<%- targetCapitalized %>">Project</th>
@@ -11,7 +11,7 @@
         </thead>
         <tbody>
         <% for (var i in data) { %>
-          <% if (data[i].state == 'completed' || data[i].state == 'archived') { continue; } %>
+          <% if (data[i].state == 'archived') { continue; } %>
           <tr>
             <td>
               <% if (data[i].state == 'draft') { %>

--- a/assets/js/backbone/apps/profiles/show/views/profile_activity_view.js
+++ b/assets/js/backbone/apps/profiles/show/views/profile_activity_view.js
@@ -36,7 +36,7 @@ var ProfileActivityView = Backbone.View.extend({
       if (_.isUndefined(data.count[this.options.data[i].state])) {
         data.count[this.options.data[i].state] = 1;
       } else {
-        data.count[this.options.data[i].state]++
+        data.count[this.options.data[i].state]++;
       }
     }
     var template = _.template(ActTemplate)(data);

--- a/assets/styles/application.css
+++ b/assets/styles/application.css
@@ -766,6 +766,11 @@ div.project-title {
   background-size: 100% 120px;
 }
 
+.task-activity-wrapper th:first-child,
+.task-createdactivity-wrapper th:first-child {
+  width: 70%;
+}
+
 #project-form input {
   margin: 5px 0 5px 0;
 }


### PR DESCRIPTION
It was observed that the profile page doesn't show tasks that the user participated in (or created) but have been subsequently marked as "Completed". We were previously using opportunities that were "Open", "Assigned", or in "Draft" state and now we've also included "Completed" in that list.

Fixes #1032 - @dhcole ready for review