### PR TITLE
Show all participants of a task in dashboard feed

### DIFF
--- a/assets/js/backbone/apps/home/templates/home_badges_feed_template.html
+++ b/assets/js/backbone/apps/home/templates/home_badges_feed_template.html
@@ -20,8 +20,7 @@
           </div>
 
           <div class="activity-feed--avatars">
-            <% window.x = b.participants; %>
-            <% b.participants.slice(0, 3).map(function(p, i) { %>
+            <% b.participants.map(function(p, i) { %>
               <a href="/profile/<%- p.id %>">
                 <div class="activity-feed--avatar" style="background-image: url(/api/user/photo/<%- p.id %>);left: <%- i * 10 %>px">&nbsp;</div>
               </a>


### PR DESCRIPTION
To fix #1034 we want to show all the participants for a given task. Previously we were explicitly selecting for just the first three, but now that has been altered to just display all participants for a given task.