### PR TITLE
An admin can add participants to an opportunity

### DIFF
--- a/api/controllers/VolunteerController.js
+++ b/api/controllers/VolunteerController.js
@@ -9,6 +9,7 @@ module.exports = {
 
   create: function (req, res) {
     var v = _.extend(req.body || {}, req.params);
+    if (v.silent) v.silent = JSON.parse(v.silent);
     Volunteer.findOrCreate(v, v, function(err, newV) {
       if (err) { return res.send(400, { message: 'Error creating volunteer entry' }); }
       return res.send(newV);

--- a/api/models/Volunteer.js
+++ b/api/models/Volunteer.js
@@ -12,12 +12,15 @@ module.exports = {
     // The task which a user volunteers for
     taskId: 'INTEGER',
     // the user that is volunteering
-    userId: 'INTEGER'
+    userId: 'INTEGER',
+    // send notification or not, after create
+    silent: 'BOOLEAN'
 
   },
 
   // create notification after creating a volunteer
   afterCreate: function(model, done) {
+    if (model.silent === true) return done();
     Notification.create({
       action: 'volunteer.create.thanks',
       model: model

--- a/api/policies/addUserId.js
+++ b/api/policies/addUserId.js
@@ -6,9 +6,13 @@ var _ = require('underscore');
 module.exports = function addUserId (req, res, next) {
   if (req.user) {
     // Check if this request is sending an object in the body
-    if (!_.isEmpty(req.body)) { req.body.userId = req.user[0].id; }
+    if (!_.isEmpty(req.body) && (!req.user[0].isAdmin)) {
+      req.body.userId = req.user[0].id;
+    }
     // If not, add the logged in user to the parameters
-    else {req.params.userId = req.user.id; }
+    else {
+      req.params.userId = req.user.id;
+    }
   }
   next();
 };

--- a/api/policies/addUserId.js
+++ b/api/policies/addUserId.js
@@ -6,8 +6,10 @@ var _ = require('underscore');
 module.exports = function addUserId (req, res, next) {
   if (req.user) {
     // Check if this request is sending an object in the body
-    if (!_.isEmpty(req.body) && (!req.user[0].isAdmin)) {
-      req.body.userId = req.user[0].id;
+    if (!_.isEmpty(req.body)) {
+      if (!req.user[0].isAdmin || (req.user[0].isAdmin && !req.body.userId)) {
+        req.body.userId = req.user[0].id;
+      }
     }
     // If not, add the logged in user to the parameters
     else {

--- a/assets/js/backbone/apps/tasks/edit/templates/task_edit_form_template.html
+++ b/assets/js/backbone/apps/tasks/edit/templates/task_edit_form_template.html
@@ -112,7 +112,12 @@
     <div class="change-project-owner" style="display: none;">
       <input style="width: 100%" id="owner" name="owner" type="hidden" value="Edit Owner"/>
     </div>
-    <h3>Participants</h3>
+    <div>
+      <h3 style="display: inline-block;">Participants</h3>
+      <% if (window.cache.currentUser.isAdmin) { %>
+      <a id="add-participant" href="#">Add</a>
+      <% } %>
+    </div>
     <% if (data.volunteers.length > 0) { %>
       <% _.each(data.volunteers, function (v) { %>
       <div class="project-people-show-div" data-userid="<%- v.userId %>" data-voluserid="<%- v.userId %>">
@@ -121,8 +126,16 @@
       </div>
       <% }); %>
     <% } else { %>
-      None assigned
+      <div class="project-no-people">
+        None assigned
+      </div>
     <% } %>
+    <div class="add-participant" style="display: none;">
+      <input style="width: 100%" id="participant" name="participant" type="hidden" value="Add participant"/>
+      <div>
+        <input type="checkbox" id="participant-notify" name="participant-notify">Notify participant</input>
+      </div>
+    </div>
 
     <h3>Progress</h3>
     <div id="div-publishedAt">

--- a/tools/postgres/migrate/10.sh
+++ b/tools/postgres/migrate/10.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Add a column to volunteers for marking notifications as silent
+psql -U midas -d midas -c "ALTER TABLE volunteer ADD COLUMN silent boolean;"
+
+# Update the schema version
+psql -U midas -d midas -c "UPDATE schema SET version = 10 WHERE schema = 'current';"

--- a/tools/postgres/schema/current.sql
+++ b/tools/postgres/schema/current.sql
@@ -1085,6 +1085,7 @@ CREATE TABLE volunteer (
     "taskId" integer,
     "userId" integer,
     id integer NOT NULL,
+    silent boolean,
     "createdAt" timestamp with time zone,
     "updatedAt" timestamp with time zone,
     "deletedAt" timestamp with time zone


### PR DESCRIPTION
This PR should close #1036, and adds a dropdown menu for admin users to the opportunity edit view. The admin user can select any user in the database to add as a participant and select to generate a notification as well.

Once the admin user completes other edits and saves their changes, the participant relationship will be created.

I think this is ready for review @dhcole.