### PR TITLE
Display working groups by default in UI

### DIFF
--- a/assets/js/backbone/config/ui.json
+++ b/assets/js/backbone/config/ui.json
@@ -1,6 +1,6 @@
 {
   "project": {
-    "show": false
+    "show": true
   },
   "supervisorEmail": {
 	  "useSupervisorEmail": false


### PR DESCRIPTION
In commit 90d08bc8a59e020e1b4cfe488686c0a937b18bab the setting default was changed from displaying working groups to hiding them. This reverts that back so that working groups are displayed by
default.

cc @ultrasaurus 