### PR TITLE
Remove double-escaping for share email template

### DIFF
--- a/assets/js/backbone/apps/tasks/show/templates/task_share_template.txt
+++ b/assets/js/backbone/apps/tasks/show/templates/task_share_template.txt
@@ -1,8 +1,9 @@
-Opportunity: <%- opportunityTitle %>
-Description: <%- opportunityDescription %>
+Opportunity: <%= opportunityTitle %>
 
-<%- opportunityMadlibs %>
+Description: <%= opportunityDescription %>
 
-I wanted to let you know about this great opportunity to help a colleague. 
+<%= opportunityMadlibs %>
 
-Click on the link to find out more: <%- opportunityLink %>
+I wanted to let you know about this great opportunity to help a colleague.
+
+Click on the link to find out more: <%= opportunityLink %>


### PR DESCRIPTION
Fixes #1069 