### PR TITLE
Add element hook to task show template

### DIFF
--- a/assets/js/backbone/apps/tasks/show/templates/task_show_item_template.html
+++ b/assets/js/backbone/apps/tasks/show/templates/task_show_item_template.html
@@ -95,6 +95,7 @@
         <% if (model.isOwner || (user && user.isAdmin)) { %>
         <div class="navbar-side <% if (user) { %>border-bottom<% } %>">
           <div id="modal-close"></div>
+          <div id="modal-copy"></div>
           <ul class="nav nav-pills nav-stacked">
             <li class="li-task-edit">
               <a href="#" id="task-edit"><i class="fa fa-pencil"></i> <span class="box-icon-text">Edit <span data-i18n="Task">Opportunity</span></span></a>


### PR DESCRIPTION
To close #1067, I added back in a `div#modal-copy` to the task show template. The modal component was given this selector to use as the `el` but it didn't exist in the DOM/page.