### PR TITLE
Agency not configurable

### DIFF
--- a/assets/js/backbone/apps/admin/templates/admin_dashboard_task_metrics.html
+++ b/assets/js/backbone/apps/admin/templates/admin_dashboard_task_metrics.html
@@ -140,7 +140,7 @@
   <table class="table task-metrics-table">
     <thead>
       <tr>
-        <th scope="col">Agencies</th>
+        <th scope="col" data-i18n="tag.AgencyPlural" ></th>
         <% _.each(range, function(key) { %>
         <th scope="col"><%- label(key) %></th>
         <% }); %>
@@ -148,7 +148,7 @@
     </thead>
     <tbody>
       <tr>
-        <th scope="row">Agencies <small>(with people who have signed up for tasks)</small></th>
+        <th scope="row"><span data-i18n="tag.AgencyPlural"></span> <small>(with people who have signed up for tasks)</small></th>
         <% _.each(range, function(key) { %>
         <td><%- agencies[key] || 0 %></td>
         <% }); %>

--- a/assets/js/backbone/apps/admin/templates/admin_tag_template.html
+++ b/assets/js/backbone/apps/admin/templates/admin_tag_template.html
@@ -6,9 +6,11 @@
       <div class="col-md-12 box-pad-b">
         <h2>Find and add tags</h2>
         <p>Search in the fields below to see existing tags. Type a new tag value to create it.</p>
-        <% _(types).forEach(function(tag) { %>
+        <% _(types).forEach(function(tag) { 
+           var tagLabel = i18n.t("tag." + tag);
+           %>
           <div class="row box-pad-b box-pad-t">
-            <label for="<%- tag %>" class="col-md-2 control-label"><%- tag %>:</label>
+            <label for="<%- tag %>" class="col-md-2 control-label"><%- tagLabel %>:</label>
             <div class="col-md-10">
               <input type="hidden" id="<%- tag %>" name="<%- tag %>" style="width: 100%"/>
               <div class="form-status text-success"></div>

--- a/assets/js/backbone/apps/browse/templates/profile_list_template.html
+++ b/assets/js/backbone/apps/browse/templates/profile_list_template.html
@@ -5,7 +5,7 @@
     <tr>
       <th width="20%">Name</th>
       <th width="30%">Title</th>
-      <th width="25%">Agency</th>
+      <th width="25%" ><%= i18n.t("tag.Agency")%></th>
       <th width="25%">Location</th>
     </tr>
     </thead>

--- a/assets/js/backbone/apps/browse/templates/profile_list_template.html
+++ b/assets/js/backbone/apps/browse/templates/profile_list_template.html
@@ -5,7 +5,7 @@
     <tr>
       <th width="20%">Name</th>
       <th width="30%">Title</th>
-      <th width="25%" ><%= i18n.t("tag.Agency")%></th>
+      <th width="25%" data-i18n="tag.Agency" ></th>
       <th width="25%">Location</th>
     </tr>
     </thead>

--- a/assets/js/backbone/apps/browse/views/browse_main_view.js
+++ b/assets/js/backbone/apps/browse/views/browse_main_view.js
@@ -39,11 +39,11 @@ var BrowseMainView = Backbone.View.extend({
         user: window.cache.currentUser,
         ui: UIConfig,
         placeholder: target === 'tasks' ?
-          "I'm looking for opportunities by name, agency, skill, topic, description..." :
+          "I'm looking for opportunities by name, " + i18n.t("tag.agency") + ", skill, topic, description..." :
           target === 'projects' ?
-          "I'm looking for working groups by name, agency, skill, topic, description..." :
+          "I'm looking for working groups by name, " + i18n.t("tag.agency") + ", skill, topic, description..." :
           target === 'profiles' ?
-          "I'm looking for people by name, title, agency, location..." :
+          "I'm looking for people by name, title,  " + i18n.t("tag.agency") + ", location..." :
           "I'm looking for..."
       };
     this.rendered = _.template(BrowseMainTemplate)(options);

--- a/assets/js/backbone/apps/browse/views/profile_list_view.js
+++ b/assets/js/backbone/apps/browse/views/profile_list_view.js
@@ -18,6 +18,7 @@ var PeopleListView = Backbone.View.extend({
     // just render the collection that you were created with (prob. everyone).
     var peopleToRender = peopleSelection ? peopleSelection : this.people;
     this.$el.html(this.template({people: peopleToRender}));
+    this.$el.i18n();
   },
 
   empty: function () {

--- a/assets/js/backbone/apps/login/templates/login_template.html
+++ b/assets/js/backbone/apps/login/templates/login_template.html
@@ -104,7 +104,7 @@
         <div class="row">
           <div class="col-sm-12">
             <div class="form-group">
-              <label for="ragency" class="control-label" data-i18n="loginModal.agency">Agency</label>
+              <label for="ragency" class="control-label" data-i18n="tag.Agency"></label>
               <input type="hidden" id="ragency" name="ragency" style="width: 100%" data-validate="empty"/>
               <span class="help-block error-empty" style="display:none;">Please select a valid agency.</span>
             </div>

--- a/assets/js/backbone/apps/profiles/show/templates/profile_edit_template.html
+++ b/assets/js/backbone/apps/profiles/show/templates/profile_edit_template.html
@@ -40,7 +40,7 @@
             </div>
 
             <div class="form-group">
-              <label for="company" class="control-label">Agency</label>
+              <label for="company" class="control-label" data-i18n="tag.Agency"></label>
               <input type="hidden" id="company" name="company" style="width: 100%"/>
             </div>
 

--- a/assets/js/backbone/apps/profiles/show/templates/profile_share_template.txt
+++ b/assets/js/backbone/apps/profiles/show/templates/profile_share_template.txt
@@ -1,5 +1,5 @@
 Name: <%- profileName %><% if(profileTitle) { %>, <%- profileTitle  %><% } %>
-Agency: <%- profileAgency  %>
+<%= i18n.t("tag.Agency")%>: <%- profileAgency  %>
 Location: <%- profileLocation  %>
 
 I wanted to let you know about this interesting person. Click on the link to see their profile: <%- profileLink  %>

--- a/assets/js/backbone/components/tag_factory.js
+++ b/assets/js/backbone/components/tag_factory.js
@@ -78,10 +78,12 @@ TagFactory = BaseComponent.extend({
     options.multiple    = (options.multiple    !== undefined ? options.multiple    : true);
     options.allowCreate = (options.allowCreate !== undefined ? options.allowCreate : true);
 
+    var tagLabel = i18n.t("tag." + options.type);
+    
     //construct the settings for this tag type
     var settings = {
 
-      placeholder:        options.placeholder || "Start typing to select a " + options.type,
+      placeholder:        options.placeholder || "Start typing to select a " + tagLabel,
       minimumInputLength: (isLocation ? 1 : 2),
       selectOnBlur:       !isLocation,
       width:              options.width || "500px",

--- a/assets/locales/en-US/translation.json
+++ b/assets/locales/en-US/translation.json
@@ -86,5 +86,15 @@
   "modalHome" : {
     "textCrowdWork" : "<section class='current'><h2>Congratulations!</h2><p>You've discovered the Department's own crowdsourcing platform. This platform was developed to facilitate collaborative work worldwide. CrowdWork organizes the work as Projects and Opportunities. Participants are Project Owners, Opportunity Requestors and Volunteers. Users can be any of these. Projects, opened by Project Owners, are the overarching groupings; and Opportunities are where requestors describe the actual work with which they would like assistance.</p><p>Users can find projects and opportunities through keyword searches or by browsing for them. Your profile is imported from Corridor and shows your interest tags, GAL information and projects and opportunities you've worked on.  If you haven’t set up a Corridor profile, start there.</p><p>CrowdWork is built for modern browsers and <i>will not work</i> with the Department installation of Internet Explorer 7. You must use Google Chrome.</p></section><section><h2>If you would like to post a Project or an Opportunity:</h2><p>Click the <span style='text-decoration: underline'>+Project</span> or <span style='text-decoration: underline'>+Opportunity</span> buttons at the top right of the next screen. If you'd like to post multiple similar volunteer opportunites, or one large one that you'd broken down into smaller, distinct parts, your first step should be to open a Project.</p><p>If you have one item to post, that is unrelated to other items, you should add an Opportunity.</p></section><section><h2>If you would like to volunteer for an Opportunity:</h2><p>You cannot volunteer for an entire <b>Project</b>, only for <b>Opportunities</b>. First talk to your supervisor about your interest in assuming the responsibility for additional work. All work performed through CrowdWork must be completed within the normal work day. Your work on CrowdWork must not interfere with your regularly assigned work or cause you to work more than your normal day to complete it. You may not work any additional hours, either compensated or uncompensated, in order to complete a CrowdWork project.</p><p>What's next? Click below to post work that you've been trying to complete for a while now. Or browse CrowdWork to see what <b>Project</b> or <b>Opportunity</b> would interest you.</p><p><input type='checkbox' class='tos-checkbox'/> I agree to the <a href=''>Terms and Conditions<a/> required to use CrowdWork.</p></section>",
     "text" : "<section class='current'><h2>Congratulations!</h2><p>Welcome to the Midas platform.</p></section><section><h2>Congratulations!</h2><p>Welcome to the Midas platform.</p></section><section><h2>Congratulations!</h2><p>Welcome to the Midas platform.</p><p><input type='checkbox' class='tos-checkbox'/> I agree to the <a href=''>Terms and Conditions<a/> required to use this platform.</p></section>"
+  },
+  
+  "tag" : {
+    "Agency": "Agency",
+    "AgencyPlural": "Agencies",
+    "agency": "agency",
+    "agencyPlural": "agencies",
+    "location": "location",
+    "skill": "skill",
+    "topic": "topic"
   }
 }

--- a/assets/locales/en/translation.json
+++ b/assets/locales/en/translation.json
@@ -78,5 +78,15 @@
   "modalHome" : {
     "textCrowdWork" : "<section class='current'><h2>Congratulations!</h2><p>You've discovered the Department's own crowdsourcing platform. This platform was developed to facilitate collaborative work worldwide. CrowdWork organizes the work as Projects and Opportunities. Participants are Project Owners, Opportunity Requestors and Volunteers. Users can be any of these. Projects, opened by Project Owners, are the overarching groupings; and Opportunities are where requestors describe the actual work with which they would like assistance.</p><p>Users can find projects and opportunities through keyword searches or by browsing for them. Your profile is imported from Corridor and shows your interest tags, GAL information and projects and opportunities you've worked on.  If you haven’t set up a Corridor profile, start there.</p><p>CrowdWork is built for modern browsers and <i>will not work</i> with the Department installation of Internet Explorer 7. You must use Google Chrome.</p></section><section><h2>If you would like to post a Project or an Opportunity:</h2><p>Click the <span style='text-decoration: underline'>+Project</span> or <span style='text-decoration: underline'>+Opportunity</span> buttons at the top right of the next screen. If you'd like to post multiple similar volunteer opportunites, or one large one that you'd broken down into smaller, distinct parts, your first step should be to open a Project.</p><p>If you have one item to post, that is unrelated to other items, you should add an Opportunity.</p></section><section><h2>If you would like to volunteer for an Opportunity:</h2><p>You cannot volunteer for an entire <b>Project</b>, only for <b>Opportunities</b>. First talk to your supervisor about your interest in assuming the responsibility for additional work. All work performed through CrowdWork must be completed within the normal work day. Your work on CrowdWork must not interfere with your regularly assigned work or cause you to work more than your normal day to complete it. You may not work any additional hours, either compensated or uncompensated, in order to complete a CrowdWork project.</p><p>What's next? Click below to post work that you've been trying to complete for a while now. Or browse CrowdWork to see what <b>Project</b> or <b>Opportunity</b> would interest you.</p><p><input type='checkbox' class='tos-checkbox'/> I agree to the <a href=''>Terms and Conditions<a/> required to use CrowdWork.</p></section>",
     "text" : "<section class='current'><h2>Congratulations!</h2><p>Welcome to the Midas platform.</p></section><section><h2>Congratulations!</h2><p>Welcome to the Midas platform.</p></section><section><h2>Congratulations!</h2><p>Welcome to the Midas platform.</p><p><input type='checkbox' class='tos-checkbox'/> I agree to the <a href=''>Terms and Conditions<a/> required to use this platform.</p></section>"
+  },
+  
+   "tag" : {
+    "Agency": "Agency",
+    "AgencyPlural": "Agencies",
+    "agency": "agency",
+    "agencyPlural": "agencies",
+    "location": "location",
+    "skill": "skill",
+    "topic": "topic"
   }
 }


### PR DESCRIPTION
Made the term "Agency" a translatable term. The term is used in several places
in the UI. It is also a "tag" item, so certain parts of the UI already were
translatable by changing the name and plural properties in
assets/js/backbone/config/tag.js.

Fix for Issue #1043 