### PR TITLE
Make the good/bad email icon not appear as a clickable link

### DIFF
--- a/assets/js/backbone/apps/login/templates/login_template.html
+++ b/assets/js/backbone/apps/login/templates/login_template.html
@@ -76,9 +76,9 @@
           <div class="input-group">
             <input type="text" class="form-control validate" id="rusername" name="username" placeholder="Email Address" data-validate="button"/>
             <span class="input-group-btn">
-              <a href="#" class="btn btn-danger" id="rusername-button" tabindex="-1">
+              <span class="btn nohover btn-danger" id="rusername-button" tabindex="-1">
                 <i id="rusername-check" class="fa fa-times"></i>
-              </a>
+              </span>
             </span>
           </div>
           <span class="help-block error-button" style="display:none;">The email address is not valid or is already in use.</span>

--- a/assets/styles/application.css
+++ b/assets/styles/application.css
@@ -2069,3 +2069,7 @@ aside a:focus {
   -moz-border-radius: 5px;
   border-radius: 5px;
 }
+
+.btn.nohover {
+  cursor: default;
+}


### PR DESCRIPTION
On the signup page I changed the good/bad email icon so that it doesn't appear clickable.  I changed the anchor tag to a span so that it doesn't show a dead link at the bottom.  I then added a new class so that the cursor isn't a pointer and doesn't look like a link.