### PR TITLE
Ensure that user activity view on profile is populated

### DIFF
--- a/assets/js/backbone/apps/profiles/show/views/profile_activity_view.js
+++ b/assets/js/backbone/apps/profiles/show/views/profile_activity_view.js
@@ -18,9 +18,13 @@ var ProfileActivityView = Backbone.View.extend({
 
   render: function () {
     // sort initially by date, descending.
-    var results = this.options.data.sort(function (a, b) {
-      return new Date(b.createdAt) - new Date(a.createdAt);
-    });
+    var results = this.options.data
+        .filter(function(i) {
+          return i && i.createdAt;
+        })
+        .sort(function (a, b) {
+          return new Date(b.createdAt) - new Date(a.createdAt);
+        });
     var data = {
       ui: UIConfig,
       target: this.options.target,


### PR DESCRIPTION
To fix #1098, we want to only pass valid task objects to the template. This PR changes some front end code to filter out any task object that doesn't have the `createdAt` field.