### PR TITLE
Update production branches in deploy documentation

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -23,7 +23,7 @@ PRs that are merged into `staging` will go through [Travis](https://travis-ci.or
 
 Once a release has been validated on staging, open a new PR for the release against `master`.
 
-PRs that are merged into `dev` will go through [Travis](https://travis-ci.org/18F/midas/builds/) for continuous integration testing and deployment.
+PRs that are merged into `master` will go through [Travis](https://travis-ci.org/18F/midas/builds/) for continuous integration testing and deployment.
 
 
 ## Cloud Foundry configuration


### PR DESCRIPTION
Making sure all the deploy instructions and branches are correct, so changed `dev` to `master` for the production deploy instructions.