### PR TITLE
Use branch of cf-blue-green that supports env var

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,14 @@ node_js:
   - "0.10"
 before_install:
   - "npm install npm@2.1.x -g"
-before_deploy: npm install -g cf-blue-green
+before_deploy: npm install -g https://github.com/18F/cf-blue-green/tarball/env-var-domain
 env:
   global:
     - CF_APP=openopps
     - CF_API=https://api.cloud.gov
     - CF_USERNAME=deploy-open-opportunities
     - CF_ORGANIZATION=open-opportunities
+    - B_DOMAIN=18f.gov
     - secure: "DTYvUyBEyP2RIk4n2KNRKhcrGo6R+KbmF/x+GUVgeVUQTL8r4jYOwjynovYmECrU4aWed68wgtA5l9KZ3tyBRZf1qJLhJBp+XD/XOLyXRvXao8HFDJD3LyQjassW9FtwXaJr8PpFGdJ45Ccn0cstEiUw9OAehMhSv26q08+gYPc="
 deploy:
   - provider: script


### PR DESCRIPTION
This defines a `B_DOMAIN` global env var in the Travis environment for use with https://github.com/18F/cf-blue-green/pull/24.

This should fix #1097 