### PR TITLE
Silence badge notifications and alter historical badge assignment script

### DIFF
--- a/api/models/Badge.js
+++ b/api/models/Badge.js
@@ -87,23 +87,28 @@ module.exports = {
    *
    * @param {object} task
    * @param {object} user
+   * @param {object} opts - optional
    * @param {function} done
    */
-  awardForTaskCompletion: function(task, user, done) {
+  awardForTaskCompletion: function(task, user, opts, done) {
     var completedAwards = {
           1: 'newcomer',
           3: 'maker',
           5: 'game changer',
           10: 'disruptor',
           15: 'partner'
-        };
+        },
+        silent = (opts && !_.isUndefined(opts.silent)) ? opts.silent : false;
+
+    // opts is optional, so the third param migth be a function
+    if (typeof opts === 'function' && !done) done = opts;
 
     if (_.has(completedAwards, user.completedTasks)) {
       var badgeQuery = {
             type: completedAwards[user.completedTasks],
             user: user.id
           },
-          badge = _.extend({}, badgeQuery, { task: task.id });
+          badge = _.extend({}, badgeQuery, { task: task.id, silent: silent });
 
       Badge.findOrCreate(badgeQuery, badge, function(err, b){
         b = [b];

--- a/api/models/Badge.js
+++ b/api/models/Badge.js
@@ -99,12 +99,13 @@ module.exports = {
         };
 
     if (_.has(completedAwards, user.completedTasks)) {
-      var badge = {
-        type: completedAwards[user.completedTasks],
-        user: user.id,
-        task: task.id
-      };
-      Badge.findOrCreate(badge, badge, function(err, b){
+      var badgeQuery = {
+            type: completedAwards[user.completedTasks],
+            user: user.id
+          },
+          badge = _.extend({}, badgeQuery, { task: task.id });
+
+      Badge.findOrCreate(badgeQuery, badge, function(err, b){
         b = [b];
         // swallow a potential error (expected) that the badge
         // already exists

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -74,19 +74,20 @@ module.exports = {
      *
      * @param {object} task
      */
-    taskCompleted: function(task) {
+    taskCompleted: function(task, opts) {
       var user = this;
+      opts = opts || {};
       this.completedTasks += 1;
       this.save(function(err, u) {
         if (err) return sails.log.error(err);
-        Badge.awardForTaskCompletion(task, user);
+        Badge.awardForTaskCompletion(task, user, opts);
       });
     },
     toJSON: function() {
       var obj = this.toObject();
       delete obj.passports;
       return obj;
-    }
+    },
   },
 
   // TODO: add more fields, likely driven off subqueries

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -75,6 +75,7 @@ module.exports = {
      * @param {object} task
      */
     taskCompleted: function(task) {
+      var user = this;
       this.completedTasks += 1;
       this.save(function(err, u) {
         if (err) return sails.log.error(err);

--- a/assets/js/backbone/apps/home/templates/home_badges_feed_template.html
+++ b/assets/js/backbone/apps/home/templates/home_badges_feed_template.html
@@ -29,7 +29,6 @@
         <% if (b.badges.length > 0) { %>
         <ul class="list-unstyled">
           <% b.badges.forEach(function(badge) { %>
-            <% console.log('badge', badge); %>
             <li>
               <% badge.type = badge.type.replace(' ', '-'); %>
               <a href="/profile/<%- badge.user.id %>"><%- badge.user.name %></a> earned the <%- badge.type %> badge. <%- badge.description %>

--- a/tools/postgres/assignHistoricalBadges.js
+++ b/tools/postgres/assignHistoricalBadges.js
@@ -14,7 +14,7 @@ Sails.lift({}, function(err, sails) {
           var vs = volunteers.map(function(vol) {
             return function(callback) {
               User.findOne({ id: vol.userId }).exec(function(err, user) {
-                user.taskCompleted(task);
+                user.taskCompleted(task, { silent: true });
                 setTimeout(function(){ callback(); }, 500);
               });
             };

--- a/tools/postgres/migrate/11.sh
+++ b/tools/postgres/migrate/11.sh
@@ -6,7 +6,7 @@ psql -U midas -d $DATABASE_URL -c "CREATE TABLE badge (
     \"task\" integer,
     id integer NOT NULL,
     \"type\" varchar,
-    \"silent\" boolean DEFAULT false,
+    \"silent\" boolean DEFAULT true,
     \"createdAt\" timestamp with time zone,
     \"updatedAt\" timestamp with time zone,
     \"deletedAt\" timestamp with time zone

--- a/tools/postgres/migrate/11.sh
+++ b/tools/postgres/migrate/11.sh
@@ -6,7 +6,7 @@ psql -U midas -d $DATABASE_URL -c "CREATE TABLE badge (
     \"task\" integer,
     id integer NOT NULL,
     \"type\" varchar,
-    \"silent\" boolean DEFAULT true,
+    \"silent\" boolean DEFAULT false,
     \"createdAt\" timestamp with time zone,
     \"updatedAt\" timestamp with time zone,
     \"deletedAt\" timestamp with time zone


### PR DESCRIPTION
This PR addresses issues that I ran into getting the badges feature onto staging:

0. Silences badge notifications as a default. Since we don't currently have a way to pass that option all the way through the historical assignment would've triggered hundreds of notifications that should've happened in the past. 
0. Updates the `assignHistoricalBadges.js` script to use the updated badge API and to provide feedback to the user running the script.
0. Fix an undefined variable error in `User.js`
0. Remove a client side logging statement that snuck through

Just as a note, I did run into the perennial issue with the `open-opportunities-theme` repo, namely I forgot to update it. I wanted to document that #906 would have been useful in this case.

As a result of the way Cloud Foundry works, when I ran `cf-ssh` with these changes in the working directory it uploaded them to the `ssh` host. Consequently, I was able to get this code on staging and run the updated historical assign script. I did this because we have an interest in getting badges on staging for socialization, though this PR should be merged and then redeployed to staging so that the `staging` branch reflects what is on the environment.

@ultrasaurus would you mind reviewing? I can then PR against `staging`.