### PR TITLE
Replaces quantifiedcode.com badge with Code Climate badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![midas](assets/images/logo.png) [![Build Status](https://travis-ci.org/18F/midas.png?branch=master)](https://travis-ci.org/18F/midas) [![Dependency Status](https://gemnasium.com/18F/midas.png)](https://gemnasium.com/18F/midas)
-[![Code Issues](https://www.quantifiedcode.com/api/v1/project/f0e67cabee2e4f8780a8b032abee3201/badge.svg)](https://www.quantifiedcode.com/app/project/f0e67cabee2e4f8780a8b032abee3201)
+<a href="https://codeclimate.com/github/18F/midas"><img src="https://codeclimate.com/github/18F/midas/badges/gpa.svg" /></a>
 =====
 
 ### Midas is a “Kickstarter for people’s time.”


### PR DESCRIPTION
        Current badge and the related link never resolve to analyzed
        code. Code Climate is free and reliable for open source
        projects, and code analysis is an important economic tool
        for determining technical debt and choosing best places to
        invest.

        This commit just inserts the HTML for the badge directly into
        the README. There are probably workarounds to keep it more
        markdown-y, but I didn't feel these made for better readabliity.